### PR TITLE
Loot Database Migration

### DIFF
--- a/ItemDrops/CratestCrateItemDropRule.cs
+++ b/ItemDrops/CratestCrateItemDropRule.cs
@@ -1,0 +1,91 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Terraria;
+using Terraria.GameContent.ItemDropRules;
+using Terraria.ModLoader;
+using UnuBattleRodsR.Items.Crates;
+using UnuBattleRodsR.Players;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class CratestCrateItemDropRule : IItemDropRule
+    {
+        private static TheCratestCrate TheCratestCrateItem => ModContent.GetInstance<TheCratestCrate>();
+        private const int DROP_MIN = 1;
+        private const int DROP_MAX = 4;
+
+        public List<IItemDropRuleChainAttempt> ChainedRules { get; private set; }
+
+        public CratestCrateItemDropRule()
+        {
+            ChainedRules = new List<IItemDropRuleChainAttempt>();
+        }
+
+        public bool CanDrop(DropAttemptInfo info)
+        {
+            return info.player.TryGetModPlayer(out FishPlayer fishPlayer) && fishPlayer.fishedCrates.Keys.Any(key => key != TheCratestCrateItem.FullName);
+        }
+
+        // We don't have access to a Player here, but ReportDroprates() should only ever be called on a client, so just use Main.LocalPlayer.
+        public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo)
+        {
+            Chains.ReportDroprates(ChainedRules, 1f, drops, ratesInfo);
+
+            if (!Main.LocalPlayer.TryGetModPlayer(out FishPlayer fishPlayer))
+            {
+                return;
+            }
+
+            Dictionary<string, int> fishedCrates = fishPlayer.fishedCrates;
+            List<int> fishedCrateTypes = [];
+            foreach (string crate in fishedCrates.Keys)
+            {
+                if (int.TryParse(crate, out int vanillaType))
+                {
+                    fishedCrateTypes.Add(vanillaType);
+                }
+                else if (ModContent.TryFind(crate, out ModItem modItem))
+                {
+                    fishedCrateTypes.Add(modItem.Type);
+                }
+            }
+            fishedCrateTypes.Remove(TheCratestCrateItem.Type);
+
+            float chance = 1f / fishedCrateTypes.Count;
+            foreach (int crateType in fishedCrateTypes)
+            {
+                drops.Add(new(crateType, DROP_MIN, DROP_MAX, chance));
+            }
+        }
+
+        public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info)
+        {
+            ItemDropAttemptResult result = default;
+
+            Dictionary<string, int> fishedCrates = info.player.GetModPlayer<FishPlayer>().fishedCrates;
+            List<int> fishedCrateTypes = [];
+            foreach (string crate in fishedCrates.Keys)
+            {
+                if (int.TryParse(crate, out int vanillaType))
+                {
+                    fishedCrateTypes.Add(vanillaType);
+                }
+                else if (ModContent.TryFind(crate, out ModItem modItem))
+                {
+                    fishedCrateTypes.Add(modItem.Type);
+                }
+            }
+            fishedCrateTypes.Remove(TheCratestCrateItem.Type);
+
+            if (fishedCrateTypes.Count == 0)
+            {
+                result.State = ItemDropAttemptResultState.FailedRandomRoll;
+                return result;
+            }
+
+            CommonCode.DropItem(info, info.rng.NextFromCollection(fishedCrateTypes), info.rng.Next(DROP_MIN, DROP_MAX + 1));
+            result.State = ItemDropAttemptResultState.Success;
+            return result;
+        }
+    }
+}

--- a/ItemDrops/DownedAncientCultistItemDropCondition.cs
+++ b/ItemDrops/DownedAncientCultistItemDropCondition.cs
@@ -1,0 +1,14 @@
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class DownedAncientCultistItemDropCondition : IItemDropRuleCondition
+    {
+        public bool CanDrop(DropAttemptInfo info) => NPC.downedAncientCultist;
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/DownedDestroyerDropCondition.cs
+++ b/ItemDrops/DownedDestroyerDropCondition.cs
@@ -1,0 +1,14 @@
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class DownedDestroyerDropCondition : IItemDropRuleCondition
+    {
+        public bool CanDrop(DropAttemptInfo info) => NPC.downedMechBoss1;
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/DownedGolemItemDropCondition.cs
+++ b/ItemDrops/DownedGolemItemDropCondition.cs
@@ -1,0 +1,14 @@
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class DownedGolemItemDropCondition : IItemDropRuleCondition
+    {
+        public bool CanDrop(DropAttemptInfo info) => NPC.downedGolemBoss;
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/DownedKingSlimeItemDropCondition.cs
+++ b/ItemDrops/DownedKingSlimeItemDropCondition.cs
@@ -1,0 +1,14 @@
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class DownedKingSlimeItemDropCondition : IItemDropRuleCondition
+    {
+        public bool CanDrop(DropAttemptInfo info) => NPC.downedSlimeKing;
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/DownedMoonLordItemDropCondition.cs
+++ b/ItemDrops/DownedMoonLordItemDropCondition.cs
@@ -1,0 +1,14 @@
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class DownedMoonLordItemDropCondition : IItemDropRuleCondition
+    {
+        public bool CanDrop(DropAttemptInfo info) => NPC.downedMoonlord;
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/DownedQueenBeeItemDropCondition.cs
+++ b/ItemDrops/DownedQueenBeeItemDropCondition.cs
@@ -1,0 +1,14 @@
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class DownedQueenBeeItemDropCondition : IItemDropRuleCondition
+    {
+        public bool CanDrop(DropAttemptInfo info) => NPC.downedQueenBee;
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/DownedSkeletronPrimeDropCondition.cs
+++ b/ItemDrops/DownedSkeletronPrimeDropCondition.cs
@@ -1,0 +1,14 @@
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class DownedSkeletronPrimeDropCondition : IItemDropRuleCondition
+    {
+        public bool CanDrop(DropAttemptInfo info) => NPC.downedMechBoss3;
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/DownedTwinsDropCondition.cs
+++ b/ItemDrops/DownedTwinsDropCondition.cs
@@ -1,0 +1,14 @@
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class DownedTwinsDropCondition : IItemDropRuleCondition
+    {
+        public bool CanDrop(DropAttemptInfo info) => NPC.downedMechBoss2;
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/DropNPCRule.cs
+++ b/ItemDrops/DropNPCRule.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.Xna.Framework;
+using System.Collections.Generic;
+using Terraria;
+using Terraria.GameContent.ItemDropRules;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class DropNPCRule : IItemDropRule
+    {
+        public int npcType;
+        public int chanceDenominator;
+        public int chanceNumerator;
+
+        public DropNPCRule(int npcType, int chanceDenominator)
+        {
+            this.npcType = npcType;
+            this.chanceDenominator = chanceDenominator;
+            this.chanceNumerator = 1;
+            ChainedRules = new List<IItemDropRuleChainAttempt>();
+        }
+
+        public DropNPCRule(int npcType, int chanceDenominator, int chanceNumerator)
+        {
+            this.npcType = npcType;
+            this.chanceDenominator = chanceDenominator;
+            this.chanceNumerator = chanceNumerator;
+            ChainedRules = new List<IItemDropRuleChainAttempt>();
+        }
+
+        public List<IItemDropRuleChainAttempt> ChainedRules { get; private set; }
+
+        public bool CanDrop(DropAttemptInfo info) => true;
+
+        public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo)
+        {
+            float personalRate = chanceNumerator / (float)chanceDenominator;
+            Chains.ReportDroprates(ChainedRules, personalRate, drops, ratesInfo);
+        }
+
+        public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info)
+        {
+            ItemDropAttemptResult result = default;
+            if (info.rng.Next(chanceDenominator) < chanceNumerator)
+            {
+                Point position = info.player.Center.ToPoint();
+                if (Main.netMode != NetmodeID.MultiplayerClient)
+                {
+                    NPC.NewNPC(info.player.GetSource_OpenItem(info.item), position.X, position.Y, npcType);
+                }
+                else
+                {
+                    ModPacket req = ModContent.GetInstance<UnuBattleRodsR>().GetPacket();
+                    req.Write((byte)UnuBattleRodsR.Message.SummonNPC);
+                    req.Write((int)npcType);
+                    req.Write((int)position.X);
+                    req.Write((int)position.Y);
+                    req.Write((int)info.item);
+                    req.Send();
+                }
+
+                result.State = ItemDropAttemptResultState.Success;
+                return result;
+            }
+
+            result.State = ItemDropAttemptResultState.FailedRandomRoll;
+            return result;
+        }
+    }
+}

--- a/ItemDrops/HasAnyItemsItemDropCondition.cs
+++ b/ItemDrops/HasAnyItemsItemDropCondition.cs
@@ -1,0 +1,31 @@
+﻿using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class HasAnyItemsItemDropCondition : IItemDropRuleCondition
+    {
+        public int[] itemTypes;
+
+        public HasAnyItemsItemDropCondition(params int[] itemTypes)
+        {
+            this.itemTypes = itemTypes;
+        }
+
+        public bool CanDrop(DropAttemptInfo info)
+        {
+            foreach (int type in itemTypes)
+            {
+                if (info.player.HasItemInInventoryOrOpenVoidBag(type))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/HasntUsedAegisFruitItemDropCondition.cs
+++ b/ItemDrops/HasntUsedAegisFruitItemDropCondition.cs
@@ -1,0 +1,13 @@
+﻿using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class HasntUsedAegisFruitItemDropCondition : IItemDropRuleCondition
+    {
+        public bool CanDrop(DropAttemptInfo info) => !info.player.usedAegisFruit;
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/NoExistingNPCsItemDropCondition.cs
+++ b/ItemDrops/NoExistingNPCsItemDropCondition.cs
@@ -1,0 +1,31 @@
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class NoExistingNPCsItemDropCondition : IItemDropRuleCondition
+    {
+        public int[] npcTypes;
+
+        public NoExistingNPCsItemDropCondition(params int[] npcTypes)
+        {
+            this.npcTypes = npcTypes;
+        }
+
+        public bool CanDrop(DropAttemptInfo info)
+        {
+            foreach (int type in npcTypes)
+            {
+                if (NPC.AnyNPCs(type))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public bool CanShowItemDropInUI() => true;
+
+        public string GetConditionDescription() => null;
+    }
+}

--- a/ItemDrops/OneFromWeightedRulesRule.cs
+++ b/ItemDrops/OneFromWeightedRulesRule.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Terraria.GameContent.ItemDropRules;
+using Terraria.Utilities;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    public class OneFromWeightedRulesRule : IItemDropRule, INestedItemDropRule
+    {
+        public Tuple<IItemDropRule, double>[] options;
+        public int chanceDenominator;
+        public int chanceNumerator;
+
+        public List<IItemDropRuleChainAttempt> ChainedRules { get; private set; }
+
+        public OneFromWeightedRulesRule(int chanceDenominator, params Tuple<IItemDropRule, double>[] options)
+            : this(chanceDenominator, 1, options) { }
+
+        public OneFromWeightedRulesRule(int chanceDenominator, int chanceNumerator, params Tuple<IItemDropRule, double>[] options)
+        {
+            this.chanceDenominator = chanceDenominator;
+            this.chanceNumerator = chanceNumerator;
+            this.options = options;
+            ChainedRules = new List<IItemDropRuleChainAttempt>();
+
+            if (chanceNumerator > chanceDenominator)
+            {
+                throw new ArgumentOutOfRangeException(nameof(chanceNumerator), $"{nameof(chanceNumerator)} must be lesser or equal to {nameof(chanceDenominator)}.");
+            }
+        }
+
+        public bool CanDrop(DropAttemptInfo info) => true;
+
+        public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info)
+        {
+            ItemDropAttemptResult result = default(ItemDropAttemptResult);
+            result.State = ItemDropAttemptResultState.DidNotRunCode;
+            return result;
+        }
+
+        public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info, ItemDropRuleResolveAction resolveAction)
+        {
+            ItemDropAttemptResult result = default;
+
+            if (info.rng.Next(chanceDenominator) < chanceNumerator)
+            {
+                WeightedRandom<IItemDropRule> weightedRandom = new(info.rng, options);
+                resolveAction(weightedRandom.Get(), info);
+                result.State = ItemDropAttemptResultState.Success;
+                return result;
+            }
+
+            result.State = ItemDropAttemptResultState.FailedRandomRoll;
+            return result;
+        }
+
+        public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo)
+        {
+            float personalRate = chanceNumerator / (float)chanceDenominator;
+            DropRateInfoChainFeed ratesWithPersonal = ratesInfo.With(personalRate);
+            double weightSum = options.Sum(option => option.Item2);
+            for (int i = 0; i < options.Length; i++)
+            {
+                options[i].Item1.ReportDroprates(drops, ratesWithPersonal.With((float)(options[i].Item2 / weightSum)));
+            }
+
+            Chains.ReportDroprates(ChainedRules, personalRate, drops, ratesInfo);
+        }
+    }
+}

--- a/ItemDrops/RepeatRules.cs
+++ b/ItemDrops/RepeatRules.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using Terraria.GameContent.ItemDropRules;
+
+namespace UnuBattleRodsR.ItemDrops
+{
+    /// <summary>
+    /// An <see cref="IItemDropRule"/> that repeats the given rule a random number of times.
+    /// </summary>
+    public class RepeatRules : IItemDropRule, INestedItemDropRule
+    {
+        public IItemDropRule[] rules;
+        public int repetitionsMinimum, repetitionsMaximum;
+        public int chanceDenominator;
+        public int chanceNumerator;
+
+        public List<IItemDropRuleChainAttempt> ChainedRules
+        {
+            get;
+            private set;
+        }
+
+        public RepeatRules(int repetitions, int chanceDenominator, params IItemDropRule[] rules)
+        {
+            this.chanceDenominator = chanceDenominator;
+            this.chanceNumerator = 1;
+            this.rules = rules;
+            this.repetitionsMinimum = this.repetitionsMaximum = repetitions;
+            ChainedRules = new List<IItemDropRuleChainAttempt>();
+        }
+
+        public RepeatRules(int repetitions, int chanceDenominator, int chanceNumerator, params IItemDropRule[] rules)
+        {
+            this.chanceDenominator = chanceDenominator;
+            this.chanceNumerator = chanceNumerator;
+            this.rules = rules;
+            this.repetitionsMinimum = this.repetitionsMaximum = repetitions;
+            ChainedRules = new List<IItemDropRuleChainAttempt>();
+        }
+
+        public RepeatRules(int repetitionsMinimum, int repetitionsMaximum, int chanceDenominator, int chanceNumerator, params IItemDropRule[] rules)
+        {
+            this.chanceDenominator = chanceDenominator;
+            this.chanceNumerator = chanceNumerator;
+            this.rules = rules;
+            this.repetitionsMinimum = repetitionsMinimum;
+            this.repetitionsMaximum = repetitionsMaximum;
+            ChainedRules = new List<IItemDropRuleChainAttempt>();
+        }
+
+        public bool CanDrop(DropAttemptInfo info) => true;
+
+        public void ReportDroprates(List<DropRateInfo> drops, DropRateInfoChainFeed ratesInfo)
+        {
+            float selfChance = chanceNumerator / (float)chanceDenominator;
+            DropRateInfoChainFeed selfRatesInfo = ratesInfo.With(selfChance);
+
+            // If the chance of a rule succeding is p and we run it n times, the chance that the rule succeeds at least once is:
+            // 1 - (1 - p)^n
+            // https://math.stackexchange.com/questions/2427183/
+            // Since n can be a random value in a range, we need to average together the chances for each possible value.
+            // sum_{i = min}^{max} (1 - (1 - p)^i)
+            // = (max - min + 1) - sum_{i = min}^{max} (1 - p)^i
+
+            int repetitionRange = repetitionsMaximum - repetitionsMinimum + 1;
+            foreach (IItemDropRule rule in rules)
+            {
+                int existingDrops = drops.Count;
+                rule.ReportDroprates(drops, selfRatesInfo);
+                for (int i = existingDrops; i < drops.Count; i++)
+                {
+                    float stackedChance = 0f;
+                    for (int j = repetitionsMinimum; j <= repetitionsMaximum; j++)
+                    {
+                        stackedChance += MathF.Pow(1f - drops[i].dropRate, j);
+                    }
+                    // Average the chance from each number of repetitions
+                    float newChance = (repetitionRange - stackedChance) / repetitionRange;
+                    drops[i] = drops[i] with
+                    {
+                        dropRate = newChance,
+                        stackMax = drops[i].stackMax * repetitionsMaximum
+                    };
+                }
+            }
+
+            Chains.ReportDroprates(ChainedRules, selfChance, drops, ratesInfo);
+        }
+
+        public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info)
+        {
+            ItemDropAttemptResult result = default(ItemDropAttemptResult);
+            result.State = ItemDropAttemptResultState.DidNotRunCode;
+            return result;
+        }
+
+        public ItemDropAttemptResult TryDroppingItem(DropAttemptInfo info, ItemDropRuleResolveAction resolveAction)
+        {
+            ItemDropAttemptResult result = default;
+            if (info.rng.Next(chanceDenominator) < chanceNumerator)
+            {
+                for (int i = 0; i < info.rng.Next(repetitionsMinimum, repetitionsMaximum + 1); i++)
+                {
+                    foreach (IItemDropRule rule in rules)
+                    {
+                        resolveAction(rule, info);
+                    }
+                }
+                result.State = ItemDropAttemptResultState.Success;
+                return result;
+            }
+
+            result.State = ItemDropAttemptResultState.FailedRandomRoll;
+            return result;
+        }
+    }
+}

--- a/Items/Crates/AlienCrate.cs
+++ b/Items/Crates/AlienCrate.cs
@@ -1,13 +1,12 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class AlienCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Alien Crate");
@@ -21,77 +20,16 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("AlienCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(25) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BrainScrambler, 1);
-            }
-            if (Main.rand.Next(12) == 0)
-            {
-                switch (Main.rand.Next(7))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Xenopopper, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.XenoStaff, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.LaserMachinegun, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.LaserDrill, 1);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ElectrosphereLauncher, 1);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ChargedBlasterCannon, 1);
-                        break;
-                    case 6:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.InfluxWaver, 1);
-                        break;
-                    case 7:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CosmicCarKey, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.AntiGravityHook, 1);
-                        break;
-                }
-            }
-            if (Main.rand.Next(6) == 0)
-            {
-                switch (Main.rand.Next(6))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MartianCostumeMask, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MartianCostumeShirt, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MartianCostumePants, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MartianUniformHelmet, 1);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MartianUniformTorso, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MartianUniformPants, 1);
-                        break;
-                }
-            }
-            if (Main.rand.Next(6) == 0)
-
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MartianConduitPlating, Main.rand.Next(10,36));
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.BrainScrambler, 25));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(12, ItemID.Xenopopper, ItemID.XenoStaff, ItemID.LaserMachinegun, ItemID.LaserDrill, ItemID.ElectrosphereLauncher, ItemID.ChargedBlasterCannon, ItemID.InfluxWaver, ItemID.CosmicCarKey, ItemID.AntiGravityHook));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(6, ItemID.MartianCostumeMask, ItemID.MartianCostumeShirt, ItemID.MartianCostumePants, ItemID.MartianUniformHelmet, ItemID.MartianUniformTorso, ItemID.MartianUniformPants));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.MartianConduitPlating, 6, 10, 35));
         }
     }
 }

--- a/Items/Crates/AnkhCrate.cs
+++ b/Items/Crates/AnkhCrate.cs
@@ -1,13 +1,12 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class AnkhCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Ankh Crate");
@@ -21,52 +20,13 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("AnkhCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            switch (Main.rand.Next(12))
-            {
-                case 0:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianSkull, 1);
-                    break;
-                case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CobaltShield, 1);
-                    break;
-                case 2:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TrifoldMap, 1);
-                    break;
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FastClock, 1);
-                    break;
-                case 4:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Vitamins, 1);
-                    break;
-                case 5:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),886, 1);
-                    break;
-                case 6:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Blindfold, 1);
-                    break;
-                case 7:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Nazar, 1);
-                    break;
-                case 8:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Megaphone, 1);
-                    break;
-                case 9:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Bezoar, 1);
-                    break;
-                case 10:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.PocketMirror, 1);
-                    break;
-                default:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.AdhesiveBandage, 1);
-                    break;
-                }
-                    base.RightClick(player);
-            }
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.ObsidianSkull, ItemID.CobaltShield, ItemID.TrifoldMap, ItemID.FastClock, ItemID.Vitamins, ItemID.ArmorPolish, ItemID.Blindfold, ItemID.Nazar, ItemID.Megaphone, ItemID.Bezoar, ItemID.PocketMirror, ItemID.AdhesiveBandage));
         }
     }
+}

--- a/Items/Crates/BeeCrate.cs
+++ b/Items/Crates/BeeCrate.cs
@@ -1,74 +1,41 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class BeeCrate : Crate
     {
+        protected override int LesserReplacement => ItemID.BottledHoney;
+
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Bee Crate");
             base.SetStaticDefaults();
             Item.ResearchUnlockCount = 10;
         }
+
         public override void SetDefaults()
         {
             base.SetDefaults();
-            LesserReplacement = ItemID.BottledHoney;
-           // AddTooltip("Right-click to open.");
-            Item.value = Item.sellPrice(0,1,0,0);
+            // AddTooltip("Right-click to open.");
+            Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("BeeCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Hive, Main.rand.Next(5, 26));
-
-            if (NPC.downedQueenBee)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.BeeWax, Main.rand.Next(5, 21));
-            }
-
-            if (Main.rand.Next(4) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Beenade, Main.rand.Next(3, 13));
-            }
-
-            if (Main.rand.Next(35) == 0)
-            {
-                switch (Main.rand.Next(3))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BeeGun);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BeeKeeper);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BeesKnees);
-                        break;
-                }
-                
-            }
-            if (Main.rand.Next(20) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.HoneyComb);
-            }
-
-            if(Main.rand.Next(50) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Nectar);
-            }
-            if (Main.rand.Next(50) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.HoneyedGoggles);
-            }
-
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Hive, 1, 5, 25));
+            itemLoot.Add(ItemDropRule.ByCondition(new DownedQueenBeeItemDropCondition(), ItemID.BeeWax, 1, 5, 20));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Beenade, 4, 3, 12));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(35, ItemID.BeeGun, ItemID.BeeKeeper, ItemID.BeesKnees));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.HoneyComb, 20));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Nectar, 50));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.HoneyedGoggles, 50));
         }
     }
 }

--- a/Items/Crates/BloodCrate.cs
+++ b/Items/Crates/BloodCrate.cs
@@ -1,13 +1,12 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class BloodCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Blood Crate");
@@ -21,54 +20,28 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("BloodCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(10) == 0)
-            {
-                if (Main.rand.Next(2) == 0)
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TopHat, 1);
-                }
-                else
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3478, 1);
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3479, 1);
-                }
-            }
-            if (Main.rand.Next(20) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MoneyTrough, 1);
-            }
-            if (Main.rand.Next(15) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SharkToothNecklace, 1);
-            }
-            if (Main.rand.Next(6) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Shackle, 1);
-            }
-            if (Main.rand.Next(6) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.BloodMoonStarter, 1);
-            }
-            if (Main.rand.Next(12) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ZombieArm, 1);
-            }
-            if (Main.hardMode && Main.rand.Next(9) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Bananarang, 1);
-            }
-            if (Main.hardMode && Main.rand.Next(18) == 0)
-            { 
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlapHand, 1);
-            }
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.ChumBucket, Main.rand.Next(1,5));
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.ChumBucket, 1, 1, 4));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.MoneyTrough, 20));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SharkToothNecklace, 15));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Shackle, 6));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.BloodMoonStarter, 6));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.ZombieArm, 12));
+
+            IItemDropRule brideVanityRule = ItemDropRule.NotScalingWithLuck(ItemID.TheBrideHat);
+            brideVanityRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.TheBrideDress));
+            itemLoot.Add(new OneFromRulesRule(10,
+                ItemDropRule.NotScalingWithLuck(ItemID.TopHat),
+                brideVanityRule
+            ));
+
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.Bananarang, 9));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.SlapHand, 18));
         }
     }
 }

--- a/Items/Crates/ChlorophyteCrate.cs
+++ b/Items/Crates/ChlorophyteCrate.cs
@@ -1,7 +1,7 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -17,44 +17,23 @@ namespace UnuBattleRodsR.Items.Crates
         public override void SetDefaults()
         {
             base.SetDefaults();
-           // AddTooltip("Right-click to open.");
+            // AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("ChlorophyteCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(2500) == 0 && Main.hardMode && NPC.downedPlantBoss)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PiranhaGun);
-            }
-            if (Main.rand.Next(100) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.TurtleShell);
-            }
-            if (Main.rand.Next(50) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Seedling);
-            }
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.ChlorophyteOre, 1, 5, 25));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.TurtleShell, 100));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Seedling, 50));
 
-            if (Main.hardMode && Main.rand.Next(25) == 0)
-            {
-                switch (Main.rand.Next(2))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Seedler);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ThornHook);
-                        break;
-                }
-            }
-
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ChlorophyteOre, Main.rand.Next(5, 26));
-           
-            base.RightClick(player);
+            IItemDropRule hardmodeRule = new LeadingConditionRule(new Conditions.IsHardmode());
+            hardmodeRule.OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(25, ItemID.Seedler, ItemID.ThornHook));
+            hardmodeRule.OnSuccess(ItemDropRule.ByCondition(new Conditions.DownedPlantera(), ItemID.PiranhaGun, 2500));
+            itemLoot.Add(hardmodeRule);
         }
     }
 }

--- a/Items/Crates/CobwebCrate.cs
+++ b/Items/Crates/CobwebCrate.cs
@@ -1,8 +1,8 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
-using UnuBattleRodsR.NPCs;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -18,109 +18,30 @@ namespace UnuBattleRodsR.Items.Crates
         public override void SetDefaults()
         {
             base.SetDefaults();
-           // AddTooltip("Right-click to open.");
+            // AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("CobwebCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if (!NPC.AnyNPCs(NPCID.Stylist) && !NPC.AnyNPCs(NPCID.WebbedStylist))
-            {
+            base.ModifyItemLoot(itemLoot);
 
-                if (Main.netMode != NetmodeID.MultiplayerClient)
-                {
-                    NPC.NewNPC(player.GetSource_ItemUse(Item), (int)player.Center.X, (int)player.Center.Y, NPCID.WebbedStylist);
-                }
-                else
-                {
-                    ModPacket req = Mod.GetPacket();
-                    req.Write((byte)UnuBattleRodsR.Message.SummonNPC);
-                    req.Write((int)NPCID.WebbedStylist);
-                    req.Write((int)player.Center.X);
-                    req.Write((int)player.Center.Y);
-                    req.Write((int)Item.type);
-                    req.Send();
-                }
-            }
-            if (Main.rand.Next(100) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.WebSlinger);
-            }
-            if (Main.rand.Next(100) == 0 && Main.hardMode)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.RuneHat);
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.RuneRobe);
-            }
-            if (Main.rand.Next(50) == 0)
-            {
-                switch (Main.rand.Next(11))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.WizardHat);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.MagicHat);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.GypsyRobe);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.AmethystRobe);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.TopazRobe);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.RubyRobe);
-                        break;
-                    case 6:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.SapphireRobe);
-                        break;
-                    case 7:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.EmeraldRobe);
-                        break;
-                    case 8:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.DiamondRobe);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.AmberRobe);
-                        break;
-                }
-                
-            }else if (Main.rand.NextBool(12))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Robe);
-            }
-            if (Main.rand.NextBool(100) && NPC.downedAncientCultist)
-            {
-                switch (Main.rand.Next(4))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.BlueLunaticRobe);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.BlueLunaticHood);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.WhiteLunaticHood);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.WhiteLunaticRobe);
-                        break;
-                }
-            }
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Cobweb, 1, 5, 25));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Silk, 1, 2, 10));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.WebSlinger, 100));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(50, ItemID.WizardHat, ItemID.MagicHat, ItemID.GypsyRobe, ItemID.AmethystRobe, ItemID.TopazRobe, ItemID.RubyRobe, ItemID.SapphireRobe, ItemID.EmeraldRobe, ItemID.DiamondRobe, ItemID.AmberRobe))
+                .OnFailedRoll(ItemDropRule.NotScalingWithLuck(ItemID.Robe, 12));
 
-            if (Main.hardMode && Main.rand.Next(5) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.SpiderFang, Main.rand.Next(1,6));
-            }
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.SpiderFang, 5, 1, 5));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.RuneHat, 100))
+                .OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.RuneRobe));
 
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Cobweb, Main.rand.Next(5, 26));
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Silk, Main.rand.Next(2, 11));
+            itemLoot.Add(new LeadingConditionRule(new DownedAncientCultistItemDropCondition()))
+                .OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(100, ItemID.BlueLunaticHood, ItemID.BlueLunaticRobe, ItemID.WhiteLunaticHood, ItemID.WhiteLunaticRobe));
 
-            base.RightClick(player);
+            itemLoot.Add(new LeadingConditionRule(new NoExistingNPCsItemDropCondition(NPCID.Stylist, NPCID.WebbedStylist)))
+                .OnSuccess(new DropNPCRule(NPCID.WebbedStylist, 1));
         }
     }
 }

--- a/Items/Crates/CorruptCrate.cs
+++ b/Items/Crates/CorruptCrate.cs
@@ -1,7 +1,7 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -20,81 +20,32 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("CorruptCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(2500) == 0 && Main.hardMode && NPC.downedPlantBoss)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ScourgeoftheCorruptor);
-            }
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.DemoniteOre, 1, 5, 25));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.ShadowScale, 3, 2, 8));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.RottenChunk, 5, 10, 30));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.VileMushroom, 3, 2, 8));
 
-            if (Main.hardMode && Main.rand.Next(25) == 0)
-            {
-                switch (Main.rand.Next(5))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DartRifle);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ChainGuillotines);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ClingerStaff);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PutridScent);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.WormHook);
-                        break;
-                }
-            }
+            IItemDropRule hardmodeRule = new LeadingConditionRule(new Conditions.IsHardmode());
+            hardmodeRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.CursedFlame, 3, 2, 7));
+            hardmodeRule.OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(25, ItemID.DartRifle, ItemID.ChainGuillotines, ItemID.ClingerStaff, ItemID.PutridScent, ItemID.WormHook));
+            hardmodeRule.OnSuccess(ItemDropRule.ByCondition(new Conditions.DownedPlantera(), ItemID.ScourgeoftheCorruptor, 2500));
+            itemLoot.Add(hardmodeRule);
 
-            if (Main.rand.Next(25) == 0)
-            {
-                switch (Main.rand.Next(5))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BandofStarpower);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Musket);
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MusketBall, 100);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Vilethorn);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BallOHurt);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ShadowOrb);
-                        break;
-                }
-            }
-
-            if (Main.hardMode && Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CursedFlame, Main.rand.Next(2, 8));
-            }
-
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DemoniteOre, Main.rand.Next(5, 26));
-            if (Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ShadowScale, Main.rand.Next(2, 9));
-            }
-            if (Main.rand.Next(5) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.RottenChunk, Main.rand.Next(10, 31));
-            }
-            if (Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.VileMushroom, Main.rand.Next(2, 9));
-            }
-            base.RightClick(player);
+            IItemDropRule musketRule = ItemDropRule.NotScalingWithLuck(ItemID.Musket);
+            musketRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.MusketBall, 1, 100, 100), hideLootReport: true);
+            itemLoot.Add(new OneFromRulesRule(25,
+                ItemDropRule.NotScalingWithLuck(ItemID.BandofStarpower),
+                musketRule,
+                ItemDropRule.NotScalingWithLuck(ItemID.Vilethorn),
+                ItemDropRule.NotScalingWithLuck(ItemID.BallOHurt),
+                ItemDropRule.NotScalingWithLuck(ItemID.ShadowOrb)
+            ));
         }
     }
 }

--- a/Items/Crates/Crate.cs
+++ b/Items/Crates/Crate.cs
@@ -1,19 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Terraria.ModLoader;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public abstract class Crate : ModItem
     {
+        protected virtual int LesserReplacement => ItemID.LesserHealingPotion;
 
-        protected int LesserReplacement = ItemID.LesserHealingPotion;
         public override void SetDefaults()
         {
             Item.CloneDefaults(ItemID.WoodenCrate);
@@ -24,337 +21,124 @@ namespace UnuBattleRodsR.Items.Crates
             return true;
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            int id=0; int stack=0;
-            if(Main.rand.Next(4) == 0)
-            {
-                spawnPotion(ref id, ref stack);
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"), id, stack);
-            }
-            if(Main.rand.Next(8) == 0)
-            {
-                spawnOres(ref id, ref stack);
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), id, stack);
-            }
-            if(Main.hardMode && Main.rand.Next(8) == 0)
-            {
-                spawnHardmodeOres(ref id, ref stack);
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), id, stack);
-            }
-            if(Main.rand.Next(16) == 0)
-            {
-                spawnGems(ref id, ref stack);
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), id, stack);
-            }
-            spawnHealthPotion(ref id, ref stack);
-            if (id == ItemID.LesserHealingPotion && LesserReplacement > 0)
-                id = LesserReplacement;
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), id,stack);
-            spawnCoins(ref id, ref stack);
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), id, stack);
-            spawnBait(ref id, ref stack);
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), id, stack);
+            #region Potions
+
+            int[] preHardmodePotions = [ItemID.MiningPotion, ItemID.IronskinPotion, ItemID.ObsidianSkinPotion, ItemID.GravitationPotion, ItemID.SpelunkerPotion, ItemID.GillsPotion, ItemID.SwiftnessPotion, ItemID.CalmingPotion];
+            int[] prePlanteraPotions = [ItemID.MiningPotion, ItemID.EndurancePotion, ItemID.ObsidianSkinPotion, ItemID.GravitationPotion, ItemID.SpelunkerPotion, ItemID.WrathPotion, ItemID.RagePotion, ItemID.GillsPotion, ItemID.SwiftnessPotion, ItemID.HeartreachPotion, ItemID.CalmingPotion,];
+            int[] postPlanteraPotions = [ItemID.MiningPotion, ItemID.EndurancePotion, ItemID.ObsidianSkinPotion, ItemID.GravitationPotion, ItemID.SpelunkerPotion, ItemID.WrathPotion, ItemID.RagePotion, ItemID.GillsPotion, ItemID.SwiftnessPotion, ItemID.HeartreachPotion, ItemID.InfernoPotion, ItemID.BattlePotion, ItemID.CalmingPotion];
+
+            itemLoot.Add(TieredDropRule(4,
+                [new OneFromRulesRule(1,
+                    [ .. preHardmodePotions.Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 2, 6)) ]
+                )],
+                [new OneFromRulesRule(1,
+                    [ .. prePlanteraPotions.Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 2, 6)) ]
+                )],
+                [new OneFromRulesRule(1,
+                    [ .. postPlanteraPotions.Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 3, 12)) ]
+                )]
+            ));
+
+            AddHealthPotionDrops(itemLoot, LesserReplacement);
+
+            #endregion Potions
+
+            #region Ores and Gems
+
+            int[] preHardmodeOres = [ItemID.CopperOre, ItemID.TinOre, ItemID.IronOre, ItemID.LeadOre, ItemID.SilverOre, ItemID.TungstenOre, ItemID.GoldOre, ItemID.PlatinumOre];
+            itemLoot.Add(new OneFromRulesRule(8,
+                [.. preHardmodeOres.Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 12, 32))]
+            ));
+
+            int[] hardmodeOres = [ItemID.CobaltOre, ItemID.PalladiumOre, ItemID.MythrilOre, ItemID.OrichalcumOre, ItemID.AdamantiteOre, ItemID.TitaniumOre];
+            itemLoot.Add(new LeadingConditionRule(new Conditions.IsHardmode()))
+                .OnSuccess(new OneFromRulesRule(8,
+                    [.. hardmodeOres.Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 12, 32))]
+            ));
+
+            int[] gems = [ItemID.Amethyst, ItemID.Topaz, ItemID.Sapphire, ItemID.Emerald, ItemID.Ruby, ItemID.Diamond];
+            itemLoot.Add(new SequentialRulesNotScalingWithLuckRule(16,
+                ItemDropRule.NotScalingWithLuck(ItemID.Amber, 16, 5, 25),
+                new OneFromRulesRule(1, [.. gems.Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 5, 25))])
+            ));
+
+            #endregion Ores and Gems
+
+            #region Misc.
+
+            itemLoot.Add(TieredDropRule(1,
+                [new OneFromRulesRule(1,
+                    ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 1, 1, 4),
+                    ItemDropRule.NotScalingWithLuck(ItemID.SilverCoin, 1, 30, 90)
+                )],
+                [ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 1, 3, 12)],
+                [ItemDropRule.NotScalingWithLuck(ItemID.GoldCoin, 1, 5, 25)]
+            ));
+
+            AddBaitDrops(itemLoot);
+
+            #endregion Misc.
         }
 
-
-        public static void spawnHealthPotion(ref int id, ref int stack)
+        // Split for use with the Crate Mimic
+        internal static void AddHealthPotionDrops(ILoot loot, int lesserReplacement = ItemID.LesserHealingPotion)
         {
-            if (!Main.hardMode)
-            {
-                id = ItemID.LesserHealingPotion; stack = Main.rand.Next(3, 21);
-            }
-            else if (!NPC.downedPlantBoss)
-            {
-                if (Main.rand.Next(4) == 0)
-                {
-                    id = ItemID.GreaterHealingPotion; stack = Main.rand.Next(1, 9);
-                }
-                else
-                {
-                    id = ItemID.HealingPotion; stack = Main.rand.Next(3, 21);
-                }
-            }
-            else
-            {
-                if (Main.rand.Next(4) == 0)
-                {
-                    id = ItemID.SuperHealingPotion; stack = Main.rand.Next(1, 9);
-                }
-                else
-                {
-                    id = ItemID.GreaterHealingPotion; stack = Main.rand.Next(3, 21);
-                }
-            }
+            loot.Add(TieredDropRule(1,
+                [ItemDropRule.NotScalingWithLuck(lesserReplacement, 1, 3, 20)],
+                [new SequentialRulesNotScalingWithLuckRule(1,
+                    ItemDropRule.NotScalingWithLuck(ItemID.GreaterHealingPotion, 4, 1, 8),
+                    ItemDropRule.NotScalingWithLuck(ItemID.HealingPotion, 1, 3, 20)
+                )],
+                [new SequentialRulesNotScalingWithLuckRule(1,
+                    ItemDropRule.NotScalingWithLuck(ItemID.SuperHealingPotion, 4, 1, 8),
+                    ItemDropRule.NotScalingWithLuck(ItemID.GreaterHealingPotion, 1, 3, 20)
+                )]
+            ));
         }
 
-        public static void spawnCoins(ref int id, ref int stack)
+        internal static void AddBaitDrops(ILoot loot)
         {
-            if (!Main.hardMode)
-            {
-               
-                if (Main.rand.Next(2) == 0)
-                {
-                    id = ItemID.GoldCoin; stack = Main.rand.Next(1, 5);
-                } else {
-                    id = ItemID.SilverCoin; stack = Main.rand.Next(30,91);
-                }
-            }
-            else if (!NPC.downedPlantBoss)
-            {
-                id = ItemID.GoldCoin; stack = Main.rand.Next(3, 13);
-            }
-            else
-            {
-                id = ItemID.GoldCoin; stack = Main.rand.Next(5, 26);
-            }
+            loot.Add(TieredDropRule(1,
+                [new OneFromRulesRule(1,
+                    ItemDropRule.NotScalingWithLuck(ItemID.ApprenticeBait, 1, 5, 15),
+                    ItemDropRule.NotScalingWithLuck(ItemID.JourneymanBait, 1, 2, 8)
+                )],
+                [new OneFromRulesRule(1,
+                    ItemDropRule.NotScalingWithLuck(ItemID.JourneymanBait, 1, 5, 15),
+                    ItemDropRule.NotScalingWithLuck(ItemID.MasterBait, 1, 2, 8)
+                )],
+                [ItemDropRule.NotScalingWithLuck(ItemID.MasterBait, 1, 5, 15)]
+            ));
         }
 
-        public static void spawnBait(ref int id, ref int stack)
+        private static SequentialRulesNotScalingWithLuckRule TieredDropRule(int chanceDenominator, IEnumerable<IItemDropRule> preHardmodeRules, IEnumerable<IItemDropRule> prePlanteraRules, IEnumerable<IItemDropRule> postPlanteraRules)
         {
-            if (!Main.hardMode)
-            { 
-                if (Main.rand.Next(2) == 0)
-                {
-                    id = ItemID.ApprenticeBait; stack = Main.rand.Next(5, 16);
-                }
-                else
-                {
-                    id = ItemID.JourneymanBait; stack = Main.rand.Next(2, 9);
-                }
-            }
-            else if (!NPC.downedPlantBoss)
+            IItemDropRule preHardmode = new LeadingConditionRule(new Conditions.IsPreHardmode());
+            foreach (IItemDropRule rule in preHardmodeRules)
             {
-                if (Main.rand.Next(2) == 0)
-                {
-                    id = ItemID.JourneymanBait; stack = Main.rand.Next(5, 16);
-                }
-                else
-                {
-                    id = ItemID.MasterBait; stack = Main.rand.Next(2, 9);
-                }
+                preHardmode.OnSuccess(rule);
             }
-            else
+
+            // Checks !NPC.downedPlantBoss
+            IItemDropRule prePlantera = new LeadingConditionRule(new Conditions.FirstTimeKillingPlantera());
+            foreach (IItemDropRule rule in prePlanteraRules)
             {
-                id = ItemID.MasterBait; stack =  Main.rand.Next(5, 16);
+                prePlantera.OnSuccess(rule);
             }
+
+            IItemDropRule postPlantera = new LeadingConditionRule(new Conditions.DownedPlantera());
+            foreach (IItemDropRule rule in postPlanteraRules)
+            {
+                postPlantera.OnSuccess(rule);
+            }
+
+            return new SequentialRulesNotScalingWithLuckRule(chanceDenominator,
+                preHardmode,
+                prePlantera,
+                postPlantera
+            );
         }
-        public static void spawnPotion(ref int id, ref int stack)
-        {
-            if (!Main.hardMode)
-            {
-                switch (Main.rand.Next(8))
-                {
-                    case 0:
-                        id = ItemID.MiningPotion;
-                        break;
-                    case 1:
-                        id = ItemID.IronskinPotion;
-                        break;
-                    case 2:
-                        id = ItemID.ObsidianSkinPotion;
-                        break;
-                    case 3:
-                        id = ItemID.GravitationPotion;
-                        break;
-                    case 4:
-                        id = ItemID.SpelunkerPotion;
-                        break;
-                    case 5:
-                        id = ItemID.GillsPotion;
-                        break;
-                    case 6:
-                        id = ItemID.SwiftnessPotion;
-                        break;
-                    default:
-                        id = ItemID.CalmingPotion;
-                        break;
-                        
-                }
-                stack = Main.rand.Next(2, 7);
-            }
-            else if (!NPC.downedPlantBoss)
-            {
-                switch (Main.rand.Next(11))
-                {
-                    case 0:
-                        id = ItemID.MiningPotion;
-                        break;
-                    case 1:
-                        id = ItemID.EndurancePotion;
-                        break;
-                    case 2:
-                        id = ItemID.ObsidianSkinPotion;
-                        break;
-                    case 3:
-                        id = ItemID.GravitationPotion;
-                        break;
-                    case 4:
-                        id = ItemID.SpelunkerPotion;
-                        break;
-                    case 5:
-                        id = ItemID.WrathPotion;
-                        break;
-                    case 6:
-                        id = ItemID.RagePotion;
-                        break;
-                    case 7:
-                        id = ItemID.GillsPotion;
-                        break;
-                    case 8:
-                        id = ItemID.SwiftnessPotion;
-                        break;
-                    case 9:
-                        id = ItemID.HeartreachPotion;
-                        break;
-                    default:
-                        id = ItemID.CalmingPotion;
-                        break;
-
-                }
-                stack = Main.rand.Next(2, 7);
-            }
-            else
-            {
-                switch (Main.rand.Next(13))
-                {
-                    case 0:
-                        id = ItemID.MiningPotion;
-                        break;
-                    case 1:
-                        id = ItemID.EndurancePotion;
-                        break;
-                    case 2:
-                        id = ItemID.ObsidianSkinPotion;
-                        break;
-                    case 3:
-                        id = ItemID.GravitationPotion;
-                        break;
-                    case 4:
-                        id = ItemID.SpelunkerPotion;
-                        break;
-                    case 5:
-                        id = ItemID.WrathPotion;
-                        break;
-                    case 6:
-                        id = ItemID.RagePotion;
-                        break;
-                    case 7:
-                        id = ItemID.GillsPotion;
-                        break;
-                    case 8:
-                        id = ItemID.SwiftnessPotion;
-                        break;
-                    case 9:
-                        id = ItemID.HeartreachPotion;
-                        break;
-                    case 10:
-                        id = ItemID.InfernoPotion;
-                        break;
-                    case 11:
-                        id = ItemID.BattlePotion;
-                        break;
-                    default:
-                        id = ItemID.CalmingPotion;
-                        break;
-
-                }
-                stack = Main.rand.Next(3, 13);
-            }
-        }
-
-        public static void spawnGems(ref int id, ref int stack)
-        {
-            if (Main.rand.Next(16) == 0)
-            {
-                id = ItemID.Amber;
-            }
-            else
-            {
-
-                switch (Main.rand.Next(6))
-                {
-                    case 0:
-                        id = ItemID.Amethyst;
-                        break;
-                    case 1:
-                        id = ItemID.Topaz;
-                        break;
-                    case 2:
-                        id = ItemID.Emerald;
-                        break;
-                    case 3:
-                        id = ItemID.Sapphire;
-                        break;
-                    case 4:
-                        id = ItemID.Ruby;
-                        break;
-                    default:
-                        id = ItemID.Diamond;
-                        break;
-                }
-            }
-            stack = Main.rand.Next(5, 26);
-        }
-
-
-        public static void spawnOres(ref int id, ref int stack)
-        {
-            switch (Main.rand.Next(8))
-            {
-                case 0:
-                    id = ItemID.CopperOre;
-                    break;
-                case 1:
-                    id = ItemID.TinOre;
-                    break;
-                case 2:
-                    id = ItemID.IronOre;
-                    break;
-                case 3:
-                    id = ItemID.LeadOre;
-                    break;
-                case 4:
-                    id = ItemID.SilverOre;
-                    break;
-                case 5:
-                    id = ItemID.TungstenOre;
-                    break;
-                case 6:
-                    id = ItemID.GoldOre;
-                    break;
-                default:
-                    id = ItemID.PlatinumOre;
-                    break;
-            }
-            stack = Main.rand.Next(12, 33);
-        }
-
-        public static void spawnHardmodeOres(ref int id, ref int stack)
-        {
-            switch (Main.rand.Next(6))
-            {
-                case 0:
-                    id = ItemID.CobaltOre;
-                    break;
-                case 1:
-                    id = ItemID.PalladiumOre;
-                    break;
-                case 2:
-                    id = ItemID.MythrilOre;
-                    break;
-                case 3:
-                    id = ItemID.OrichalcumOre;
-                    break;
-                case 4:
-                    id = ItemID.AdamantiteOre;
-                    break;
-                default:
-                    id = ItemID.TitaniumOre;
-                    break;
-            }
-            stack = Main.rand.Next(12, 33);
-        }
-
     }
 }

--- a/Items/Crates/CrimsonCrate.cs
+++ b/Items/Crates/CrimsonCrate.cs
@@ -1,13 +1,12 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class CrimsonCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Crimson Crate");
@@ -20,85 +19,33 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("CrimsonCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if(Main.rand.Next(2500) == 0 && Main.hardMode && NPC.downedPlantBoss)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.VampireKnives);
-            }
+            base.ModifyItemLoot(itemLoot);
 
-            if(Main.rand.Next(50)==0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeatGrinder, 1);
-            }
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.CrimtaneOre, 1, 5, 25));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.TissueSample, 3, 2, 8));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Vertebrae, 5, 10, 30));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.ViciousMushroom, 3, 2, 8));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.MeatGrinder, 50));
 
-            if (Main.hardMode && Main.rand.Next(25) == 0)
-            {
-                switch (Main.rand.Next(5))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DartPistol);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FetidBaghnakhs);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SoulDrain);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FleshKnuckles);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TendonHook);
-                        break;
-                }
-            }
+            IItemDropRule hardmodeRule = new LeadingConditionRule(new Conditions.IsHardmode());
+            hardmodeRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.Ichor, 3, 2, 7));
+            hardmodeRule.OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(25, ItemID.DartPistol, ItemID.FetidBaghnakhs, ItemID.SoulDrain, ItemID.FleshKnuckles, ItemID.TendonHook));
+            hardmodeRule.OnSuccess(ItemDropRule.ByCondition(new Conditions.DownedPlantera(), ItemID.VampireKnives, 2500));
+            itemLoot.Add(hardmodeRule);
 
-            if(Main.rand.Next(25) == 0)
-            {
-                switch (Main.rand.Next(5))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PanicNecklace);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TheUndertaker);
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MusketBall, 100);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CrimsonRod);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TheRottedFork);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CrimsonHeart);
-                        break;
-                }
-            }
-
-            if(Main.hardMode && Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Ichor, Main.rand.Next(2, 8));
-            }
-
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CrimtaneOre, Main.rand.Next(5, 26));
-            if (Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TissueSample, Main.rand.Next(2, 9));
-            }
-            if (Main.rand.Next(5) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Vertebrae, Main.rand.Next(10, 31));
-            }
-            if (Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.ViciousMushroom, Main.rand.Next(2, 9));
-            }
-            base.RightClick(player);
+            IItemDropRule undertakerRule = ItemDropRule.NotScalingWithLuck(ItemID.TheUndertaker);
+            undertakerRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.MusketBall, 1, 100, 100), hideLootReport: true);
+            itemLoot.Add(new OneFromRulesRule(25,
+                ItemDropRule.NotScalingWithLuck(ItemID.PanicNecklace),
+                undertakerRule,
+                ItemDropRule.NotScalingWithLuck(ItemID.CrimsonRod),
+                ItemDropRule.NotScalingWithLuck(ItemID.TheRottedFork),
+                ItemDropRule.NotScalingWithLuck(ItemID.CrimsonHeart)
+            ));
         }
     }
 }

--- a/Items/Crates/Crittercrate.cs
+++ b/Items/Crates/Crittercrate.cs
@@ -1,13 +1,13 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class CritterCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Critter Crate");
@@ -20,174 +20,19 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("CritterCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            int Crittercount = Main.rand.Next(1, 4);
-            for (int i = 0; i < Crittercount; i++)
-            {
-                BaitSelect(player);
-                ButterflySelect(player);
-                Critterselect(player);
-            }
-            base.RightClick(player);
-        }
+            base.ModifyItemLoot(itemLoot);
 
-        public void BaitSelect(Player player)
-        {
-            if (NPC.downedGolemBoss && Main.rand.Next(15) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.EmpressButterfly, 1);
-            }
-            if (Main.hardMode && Main.rand.Next(15)==0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TruffleWorm, 1);
-            }
-            switch (Main.rand.Next(12)) {
-                 case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BlackScorpion, 1);
-                    break;
-                 case 2:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Buggy, 1);
-                    break;
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.EnchantedNightcrawler, 1);
-                    break;
-                case 4:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Grasshopper, 1);
-                    break;
-                case 5:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldGrasshopper, 1);
-                    break;
-                case 6:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Grubby, 1);
-                    break;
-                case 7:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GlowingSnail, 1);
-                    break;
-                case 8:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Scorpion, 1);
-                    break;
-                case 9:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Sluggy, 1);
-                    break;
-                case 10:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Snail, 1);
-                    break;
-                case 11:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Worm, 1);
-                    break;
-                default:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldWorm, 1);
-                    break;
-            }
+            itemLoot.Add(new RepeatRules(1, 3, 1, 1,
+                ItemDropRule.ByCondition(new DownedGolemItemDropCondition(), ItemID.EmpressButterfly, 15),
+                ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.TruffleWorm, 15),
+                ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.BlackScorpion, ItemID.Buggy, ItemID.EnchantedNightcrawler, ItemID.Grasshopper, ItemID.GoldGrasshopper, ItemID.Grubby, ItemID.GlowingSnail, ItemID.Scorpion, ItemID.Sluggy, ItemID.Snail, ItemID.Worm, ItemID.GoldWorm),
+                ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.Firefly, ItemID.LightningBug, ItemID.GoldButterfly, ItemID.JuliaButterfly, ItemID.MonarchButterfly, ItemID.PurpleEmperorButterfly, ItemID.RedAdmiralButterfly, ItemID.SulphurButterfly, ItemID.TreeNymphButterfly, ItemID.UlyssesButterfly, ItemID.ZebraSwallowtailButterfly),
+                ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.Bird, ItemID.GoldBird, ItemID.BlueJay, ItemID.Bunny, ItemID.GoldBunny, ItemID.Cardinal, ItemID.Duck, ItemID.Frog, ItemID.GoldFrog, ItemID.Goldfish, ItemID.MallardDuck, ItemID.Mouse, ItemID.GoldMouse, ItemID.Penguin, ItemID.SquirrelRed, ItemID.Squirrel, ItemID.SquirrelGold)
+            ));
         }
-
-        public void ButterflySelect(Player player)
-        {
-                switch (Main.rand.Next(11))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Firefly, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.LightningBug, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldButterfly, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.JuliaButterfly, 1);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MonarchButterfly, 1);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PurpleEmperorButterfly, 1);
-                        break;
-                    case 6:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.RedAdmiralButterfly, 1);
-                        break;
-                    case 7:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SulphurButterfly, 1);
-                        break;
-                    case 8:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TreeNymphButterfly, 1);
-                        break;
-                    case 9:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.UlyssesButterfly, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ZebraSwallowtailButterfly, 1);
-                        break;
-                }
-            
-        }
-
-        public void Critterselect(Player player)
-        {
-            switch (Main.rand.Next(17))
-            {
-                case 0:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Bird, 1);
-                    break;
-                case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldBird, 1);
-                    break;
-               
-                case 2:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BlueJay, 1);
-                    break;
-                
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Bunny, 1);
-                    break;
-                case 4:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldBunny, 1);
-                    break;
-                case 5:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Cardinal, 1);
-                    break;
-                case 6:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Duck, 1);
-                    break;
-                case 7:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Frog, 1);
-                    break;
-                case 8:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldFrog, 1);
-                    break;
-                
-                case 9:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Goldfish, 1);
-                    break;
-               
-                case 10:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MallardDuck, 1);
-                    break;
-                case 11:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Mouse, 1);
-                    break;
-                case 12:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldMouse, 1);
-                    break;
-                case 13:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Penguin, 1);
-                    break;
-                case 14:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3563, 1);
-                    break;
-                
-                case 15:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Squirrel, 1);
-                    break;
-                case 16:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SquirrelGold, 1);
-                    break;
-                
-                       }
-         }
-      }
-   }
+    }
+}

--- a/Items/Crates/DyeCrate.cs
+++ b/Items/Crates/DyeCrate.cs
@@ -1,7 +1,10 @@
-﻿using Terraria.ModLoader;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -18,66 +21,27 @@ namespace UnuBattleRodsR.Items.Crates
             base.SetDefaults();
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("DyeCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            switch (Main.rand.Next(14))
-            {
-                case 0:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.RedHusk, Main.rand.Next(2, 6));
-                    break;
-                case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.OrangeBloodroot, Main.rand.Next(2, 6));
-                    break;
-                case 2:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.YellowMarigold, Main.rand.Next(2, 6));
-                    break;
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LimeKelp, Main.rand.Next(2, 6));
-                    break;
-                case 4:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.GreenMushroom, Main.rand.Next(2, 6));
-                    break;
-                case 6:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.TealMushroom, Main.rand.Next(2, 6));
-                    break;
-                case 7:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.CyanHusk, Main.rand.Next(2, 6));
-                    break;
-                case 8:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.SkyBlueFlower, Main.rand.Next(2, 6));
-                    break;
-                case 9:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.BlueBerries, Main.rand.Next(2, 6));
-                    break;
-                case 10:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.PurpleMucos, Main.rand.Next(2, 6));
-                    break;
-                case 11:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.VioletHusk, Main.rand.Next(2, 6));
-                    break;
-                case 12:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.PinkPricklyPear, Main.rand.Next(2, 6));
-                    break;
-                default:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.BlackInk, Main.rand.Next(2, 6));
-                    break;
-            }
-            
-            for(int i = 0; i < 100; i++)
-            {
-                Item itm = ContentSamples.ItemsByType[Main.rand.Next(ItemLoader.ItemCount)];
-                if(itm.dye > 0)
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), itm.type, Main.rand.Next(1, 4));
-                    base.RightClick(player);
-                    return;
-                }
-            }
+            base.ModifyItemLoot(itemLoot);
 
-            base.RightClick(player);
+            int[] ingredients = [ItemID.RedHusk, ItemID.OrangeBloodroot, ItemID.YellowMarigold, ItemID.LimeKelp, ItemID.GreenMushroom, ItemID.TealMushroom, ItemID.CyanHusk, ItemID.SkyBlueFlower, ItemID.BlueBerries, ItemID.PurpleMucos, ItemID.VioletHusk, ItemID.PinkPricklyPear, ItemID.BlackInk];
+            IEnumerable<IItemDropRule> ingredientRules = ingredients.Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 2, 5));
+            itemLoot.Add(new OneFromRulesRule(14, ingredientRules.ToArray()));
+
+            // Previously, the rule tried up to 100 random item types and dropped the first dye it found.
+            // With k items and n dyes, the chance of any one item being a dye is n/k.
+            // Attempting r times, the chance at least one of those attempts succeeds is p = 1 - (1 - (n/k))^r
+            // https://math.stackexchange.com/questions/2427183/
+            IEnumerable<IItemDropRule> dyeRules = ContentSamples.ItemsByType.Values
+                .Where(i => i.dye > 0)
+                .Select(i => ItemDropRule.NotScalingWithLuck(i.type, 1, 1, 3));
+            double dyeCount = dyeRules.Count();
+            double probabilityOfAtLeast1 = 1.0 - Math.Pow(1.0 - (dyeCount / ItemLoader.ItemCount), 100);
+            int numerator = (int)(probabilityOfAtLeast1 * 100);
+            itemLoot.Add(new OneFromRulesRule(100, numerator, dyeRules.ToArray()));
         }
     }
 }

--- a/Items/Crates/EclipseCrate.cs
+++ b/Items/Crates/EclipseCrate.cs
@@ -1,13 +1,14 @@
-﻿using Terraria.ModLoader;
+﻿using System.Collections.Generic;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class EclipseCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Eclipse Crate");
@@ -20,84 +21,33 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("EclipseCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if (Main.rand.Next(7) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ButchersChainsaw ,1);
-            }
-            if (Main.rand.Next(7) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.NeptunesShell, 1);
-            }
-            if (Main.rand.Next(7) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DeadlySphereStaff, 1);
-            }
-            if (Main.rand.Next(7) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ToxicFlask, 1);
-            }
-            if (Main.rand.Next(7) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.NailGun, 1);
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Nail, Main.rand.Next (25,76));
-            }
-            if (Main.rand.Next(7) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DeathSickle, 1);
-            }
-            if (Main.rand.Next(7) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BrokenBatWing, 1);
-            }
-            if (Main.rand.Next(7) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MoonStone, 1);
-            }
-            if (Main.rand.Next(20) == 0 && NPC.downedGolemBoss)
-            {
-                if (UnuBattleRodsR.thoriumPresent)
-                {
-                    switch (Main.rand.Next(4))
-                    {
-                        case 0:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BrokenHeroSword, 1);
-                            break;
-                        case 1:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),UnuBattleRodsR.getItemTypeFromTag("ThoriumMod:BrokenHeroScythe"), 1);
-                            break;
-                        case 2:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),UnuBattleRodsR.getItemTypeFromTag("ThoriumMod:BrokenHeroStaff"), 1);
-                            break;
-                        default:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),UnuBattleRodsR.getItemTypeFromTag("ThoriumMod:BrokenHeroBow"), 1);
-                            break;
-                    }
+            base.ModifyItemLoot(itemLoot);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Nail, 3, 25, 75));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.ButchersChainsaw, 7));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.NeptunesShell, 7));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.DeadlySphereStaff, 7));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.ToxicFlask, 7));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.DeathSickle, 7));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.BrokenBatWing, 7));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.MoonStone, 7));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.NailGun, 7))
+                .OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.Nail, 1, 25, 75), hideLootReport: true);
 
-                }else
-                {
+            IItemDropRule downedGolemCondition = new LeadingConditionRule(new DownedGolemItemDropCondition());
+            downedGolemCondition.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.MothronWings, 200));
+            downedGolemCondition.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.TheEyeOfCthulhu, 200));
 
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BrokenHeroSword, 1);
-                }
-                if (Main.rand.Next(10) == 0)
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MothronWings, 1);
-                }
-                if (Main.rand.Next(10) == 0)
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TheEyeOfCthulhu, 1);
-                }
-
-            }
-            if (Main.rand.Next(3) == 0)
+            List<IItemDropRule> brokenHeroItems = [ItemDropRule.NotScalingWithLuck(ItemID.BrokenHeroSword)];
+            if (ModLoader.TryGetMod("ThoriumMod", out Mod thoriumMod) && thoriumMod.TryFind("BrokenHeroFragment", out ModItem brokenHeroFragment))
             {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Nail, Main.rand.Next(25, 76));
+                brokenHeroItems.Add(ItemDropRule.NotScalingWithLuck(brokenHeroFragment.Type, 1, 1, 3));
             }
-            base.RightClick(player);
+            downedGolemCondition.OnSuccess(new OneFromRulesRule(20, [.. brokenHeroItems]));
+            itemLoot.Add(downedGolemCondition);
         }
     }
 }

--- a/Items/Crates/FlowerCrate.cs
+++ b/Items/Crates/FlowerCrate.cs
@@ -1,16 +1,15 @@
-﻿using Terraria.ModLoader;
+﻿using System;
+using System.Linq;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
-using System.Collections.Generic;
-using System.Collections;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class FlowerCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             base.SetStaticDefaults(); Item.ResearchUnlockCount = 10;
@@ -21,12 +20,25 @@ namespace UnuBattleRodsR.Items.Crates
             base.SetDefaults();
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("FlowerCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            List<int> flowers = new List<int>()
+            // Do not drop normal crate loot
+            //base.ModifyItemLoot(itemLoot);
+
+            IItemDropRule equipmentRule = new OneFromWeightedRulesRule(10,
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.AbigailsFlower), 1.0),
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.FlowerofFire), 1.0),
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.JungleRose), 1.0),
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.NaturesGift), 1.0),
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.ObsidianRose), 1.0),
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.FlowerBoots), 3.0)
+            );
+            equipmentRule.OnFailedRoll(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.FlowerofFrost, 10));
+            itemLoot.Add(equipmentRule);
+
+            int[] flowers =
             {
                 ItemID.Daybloom,
                 ItemID.Moonglow,
@@ -37,53 +49,17 @@ namespace UnuBattleRodsR.Items.Crates
                 ItemID.Shiverthorn,
                 ItemID.Sunflower,
             };
-            List<int> flowerSeeds = new List<int>()
-            {
-                ItemID.FlowerPacketWild
-            };
-            for(int i = 4041; i <= 4048; i++)
-            {
-                flowerSeeds.Add(i);
-            }
+            IItemDropRule flowerRule = new OneFromRulesRule(1, flowers.Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 1, 3)).ToArray());
 
-            if (Main.rand.NextBool(10))
-            {
-                switch (Main.rand.Next(8)) {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.AbigailsFlower, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.FlowerofFire, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.JungleRose, 1);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.NaturesGift, 1);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.ObsidianRose, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.FlowerBoots, 1);
-                        break;
-                }
-            }else if (Main.hardMode && Main.rand.NextBool(10))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.FlowerofFrost, 1);
-            }
+            IItemDropRule seedsRule = new OneFromRulesRule(1, ItemID.Sets.flowerPacketInfo
+                .Select((value, type) => type)
+                .Where(type => type < ItemID.Count && ItemID.Sets.flowerPacketInfo[type] != null)
+                .Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 1, 3))
+                .ToArray());
 
-            for (int i = 0; i < 3; i++)
-            {
-                if (Main.rand.NextBool())
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), flowers[Main.rand.Next(0, flowers.Count)], Main.rand.Next(1, 4));
-                }
-                else
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), flowerSeeds[Main.rand.Next(0, flowerSeeds.Count)], Main.rand.Next(1, 4));
-                }
-            }            
+            itemLoot.Add(new RepeatRules(3, 1,
+                new OneFromRulesRule(1, flowerRule, seedsRule)
+            ));
         }
-      }
-   }
+    }
+}

--- a/Items/Crates/FrostLegionCrate.cs
+++ b/Items/Crates/FrostLegionCrate.cs
@@ -1,13 +1,12 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class FrostLegionCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Frost Legion Crate");
@@ -20,24 +19,17 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("FrostLegionCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-         player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SnowBlock, Main.rand.Next(1, 1000));
-         player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SnowGlobe, 1);
-         player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),1869, Main.rand.Next(1, 4));
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(2) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Snowball, Main.rand.Next(1, 1000));
-            }
-            if (Main.rand.Next(2) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.IceBlock, Main.rand.Next(1, 1000));
-            }
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SnowBlock, 1, 1, 999));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Snowball, 2, 1, 999));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.IceBlock, 2, 1, 999));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SnowGlobe));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Present, 1, 1, 3));
         }
     }
 }

--- a/Items/Crates/FrostMoonCrate.cs
+++ b/Items/Crates/FrostMoonCrate.cs
@@ -1,13 +1,12 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class FrostMoonCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Frost Moon Crate");
@@ -20,87 +19,29 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("FrostMoonCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if (Main.rand.Next(3) == 0)
-            {
-                switch (Main.rand.Next(3))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ElfHat);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ElfShirt);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ElfPants);
-                        break;
-                }
-            }
-            if (Main.rand.Next(7) == 0)
-            {
-                    switch (Main.rand.Next(4))
-                    {
-                        case 0:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ChristmasTreeSword);
-                            break;
-                        case 1:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Razorpine);
-                            break;
-                        case 2:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FestiveWings);
-                            break;
-                        default:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ChristmasHook);
-                            break;
-                    }
-                }
-            if (Main.rand.Next(10) == 0)
-            {
-                switch (Main.rand.Next(2))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),1910);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ChainGun);
-                        break;
-                }
-            }
-            if (Main.rand.Next(15) == 0)
-                {
-                    switch (Main.rand.Next(5))
-                    {
-                        case 0:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BlizzardStaff);
-                            break;
-                        case 1:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.NorthPole, (1));
-                            break;
-                        case 2:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SnowmanCannon, (1));
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Snowball, Main.rand.Next(25,100));
-                        break;
-                        case 3:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BabyGrinchMischiefWhistle, (1));
-                            break;
-                        default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ReindeerBells, (1));
-                            break;
-                    }
-                }
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(5) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.NaughtyPresent, (1));
-                    }
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Present, 1, 1, 9));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.NaughtyPresent, 5));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(3, ItemID.ElfHat, ItemID.ElfShirt, ItemID.ElfPants));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(7, ItemID.ChristmasTreeSword, ItemID.Razorpine, ItemID.FestiveWings, ItemID.ChristmasHook));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(10, ItemID.ElfMelter, ItemID.ChainGun));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(15, ItemID.ChristmasTreeSword, ItemID.Razorpine, ItemID.FestiveWings, ItemID.ChristmasHook));
 
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Present, Main.rand.Next(1, 10));
+            IItemDropRule snowmanCannonRule = ItemDropRule.NotScalingWithLuck(ItemID.SnowmanCannon);
+            snowmanCannonRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.Snowball, 1, 25, 99), hideLootReport: true);
+            itemLoot.Add(new OneFromRulesRule(15,
+                ItemDropRule.NotScalingWithLuck(ItemID.BlizzardStaff),
+                ItemDropRule.NotScalingWithLuck(ItemID.NorthPole),
+                snowmanCannonRule,
+                ItemDropRule.NotScalingWithLuck(ItemID.BabyGrinchMischiefWhistle),
+                ItemDropRule.NotScalingWithLuck(ItemID.ReindeerBells)
 
-            base.RightClick(player);
-            }
+            ));
         }
     }
+}

--- a/Items/Crates/FruitCrate.cs
+++ b/Items/Crates/FruitCrate.cs
@@ -1,15 +1,14 @@
-﻿using Terraria.ModLoader;
+﻿using System.Linq;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
-using System.Collections.Generic;
-using System.Collections;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class FruitCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             base.SetStaticDefaults(); Item.ResearchUnlockCount = 10;
@@ -20,12 +19,29 @@ namespace UnuBattleRodsR.Items.Crates
             base.SetDefaults();
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("FruitCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            List<int> fruits = new List<int>()
+            // Do not drop normal crate loot
+            //base.ModifyItemLoot(itemLoot);
+
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.JunimoPetItem, 1000));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Spaghetti, 1000, 1, 3));
+
+            IItemDropRule hardmodeRule = new LeadingConditionRule(new Conditions.IsHardmode());
+            hardmodeRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.Bananarang, 100));
+            hardmodeRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.BlessedApple, 250));
+
+            IItemDropRule specialFruitRule = new LeadingConditionRule(new Conditions.BeatAnyMechBoss());
+            specialFruitRule.OnSuccess(new SequentialRulesNotScalingWithLuckRule(25,
+                ItemDropRule.ByCondition(new HasntUsedAegisFruitItemDropCondition(), ItemID.AegisFruit, 10),
+                ItemDropRule.NotScalingWithLuck(ItemID.LifeFruit)
+            ));
+            hardmodeRule.OnSuccess(specialFruitRule);
+            itemLoot.Add(hardmodeRule);
+
+            int[] fruits =
             {
                 ItemID.Apple,
                 ItemID.Apricot,
@@ -52,39 +68,10 @@ namespace UnuBattleRodsR.Items.Crates
                 ItemID.Grapes,
             };
 
-            if(Main.rand.NextBool(1000))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), 5276, 1);
-            }
-            if (Main.rand.NextBool(1000))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Spaghetti, Main.rand.Next(1, 4));
-            }
-
-            if (Main.hardMode && Main.rand.NextBool(100))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Bananarang, 1);
-            }
-            if (Main.hardMode && Main.rand.NextBool(250))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.BlessedApple, 1);
-            }
-            if (Main.hardMode && Main.rand.NextBool(25) && NPC.downedMechBossAny)
-            {
-                if(Main.rand.NextBool(10) && !player.usedAegisFruit)
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.AegisFruit, 1);
-                }
-                else
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LifeFruit, 1);
-                }
-            }
-
-            for(int i = 0; i < 3; i++)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), fruits[Main.rand.Next(0, fruits.Count)], Main.rand.Next(1,4));
-            }            
+            IItemDropRule fruitsRule = new OneFromRulesRule(1, fruits
+                .Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 1, 3))
+                .ToArray());
+            itemLoot.Add(new RepeatRules(3, 1, fruitsRule));
         }
-      }
-   }
+    }
+}

--- a/Items/Crates/GeodeCrate.cs
+++ b/Items/Crates/GeodeCrate.cs
@@ -1,8 +1,9 @@
-﻿using Terraria.ModLoader;
+﻿using System.Linq;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
-using Microsoft.Build.Tasks.Deployment.ManifestUtilities;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -19,63 +20,22 @@ namespace UnuBattleRodsR.Items.Crates
             base.SetDefaults();
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("GeodeCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            int rolls = Main.rand.Next(1,4);
-            for (int i = 0; i < rolls; i++)
-            {
-                switch (Main.rand.Next(6))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Topaz, Main.rand.Next(2, 6));
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Amethyst, Main.rand.Next(2, 6));
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Emerald, Main.rand.Next(2, 6));
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Ruby, Main.rand.Next(2, 6));
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Sapphire, Main.rand.Next(2, 6));
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Diamond, Main.rand.Next(2, 6));
-                        break;
-                }
-            }
-            if (Main.rand.NextBool(50))
-            {                
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.AmberMosquito);
-            }
-            if (Main.rand.NextBool(5))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Amber, Main.rand.Next(2, 6));
-            }
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.hardMode && Main.rand.NextBool(25))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Geode, Main.rand.Next(2, 6));
-            }
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Amber, 5, 2, 5));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.AmberMosquito, 50));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.Geode, 25, 2, 5));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.QueenSlimeCrystal, 20))
+                .OnFailedRoll(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.CrystalShard, 1, 2, 5));
 
-            if (Main.hardMode)
-            {
-                if (Main.rand.NextBool(20))
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.QueenSlimeCrystal);
-                }
-                else
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.CrystalShard, Main.rand.Next(2, 6));
-                }
-            }
-            
-            base.RightClick(player);
+            int[] gems = [ItemID.Amethyst, ItemID.Topaz, ItemID.Sapphire, ItemID.Emerald, ItemID.Ruby, ItemID.Diamond];
+            itemLoot.Add(new RepeatRules(1, 3, 1, 1,
+                new OneFromRulesRule(1, gems.Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 2, 5)).ToArray())
+            ));
         }
     }
 }

--- a/Items/Crates/GoblinCrate.cs
+++ b/Items/Crates/GoblinCrate.cs
@@ -1,13 +1,14 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
+using UnuBattleRodsR.Items.Materials;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class GoblinCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Goblin Crate");
@@ -20,55 +21,20 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("GoblinCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if (!NPC.AnyNPCs(NPCID.GoblinTinkerer) && !NPC.AnyNPCs(NPCID.BoundGoblin))
-            {
+            base.ModifyItemLoot(itemLoot);
 
-                if (Main.netMode != NetmodeID.MultiplayerClient)
-                {
-                    NPC.NewNPC(player.GetSource_ItemUse(Item), (int)player.Center.X, (int)player.Center.Y, NPCID.BoundGoblin);
-                }
-                else
-                {
-                    ModPacket req = Mod.GetPacket();
-                    req.Write((byte)UnuBattleRodsR.Message.SummonNPC);
-                    req.Write((int)NPCID.BoundGoblin);
-                    req.Write((int)player.Center.X);
-                    req.Write((int)player.Center.Y);
-                    req.Write((int)Item.type);
-                    req.Send();
-                }
-            }
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SpikyBall, 1, 10, 150));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Harpoon, 5));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ModContent.ItemType<Shadowflame>(), 5, 1, 4));
 
-            if (Main.rand.Next(5) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Harpoon, 1);
-            }
-            if (Main.rand.Next(10) == 0 && Main.hardMode)
-            {
-                switch (Main.rand.Next(3))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ShadowFlameHexDoll, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ShadowFlameKnife, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ShadowFlameBow, 1);
-                        break;
-                }
-            }
-            if (Main.rand.Next(5) == 0 && Main.hardMode)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),Mod.Find<ModItem>("Shadowflame").Type, Main.rand.Next(1, 5));
-            }
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpikyBall, Main.rand.Next(10,150));
-            base.RightClick(player);
+            itemLoot.Add(new LeadingConditionRule(new NoExistingNPCsItemDropCondition(NPCID.GoblinTinkerer, NPCID.BoundGoblin)))
+                .OnSuccess(new DropNPCRule(NPCID.BoundGoblin, 1));
+            itemLoot.Add(new LeadingConditionRule(new Conditions.IsHardmode()))
+                .OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(10, ItemID.ShadowFlameKnife, ItemID.ShadowFlameBow, ItemID.ShadowFlameHexDoll));
         }
     }
 }

--- a/Items/Crates/GraniteCrate.cs
+++ b/Items/Crates/GraniteCrate.cs
@@ -1,7 +1,7 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -19,89 +19,16 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("GraniteCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if(Main.rand.Next(20) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.NightVisionHelmet);
-            }
-            
-
-            if (Main.rand.Next(5) == 0)
-            {
-                switch (Main.rand.Next(3))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteGolemStatue);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.WomanStatue);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SkeletonStatue);
-                        break;
-                }
-            }
-
-            switch (Main.rand.Next(16))
-            {
-                case 0:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteBathtub);
-                    break;
-                case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteBed);
-                    break;
-                case 2:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteBookcase);
-                    break;
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteCandelabra);
-                    break;
-                case 4:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteCandle);
-                    break;
-                case 5:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteChair);
-                    break;
-                case 6:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteChandelier);
-                    break;
-                case 7:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteChest);
-                    break;
-                case 8:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteClock);
-                    break;
-                case 9:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteDresser);
-                    break;
-                case 10:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteLamp);
-                    break;
-                case 11:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteLantern);
-                    break;
-                case 12:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GranitePiano);
-                    break;
-                case 13:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteSink);
-                    break;
-                case 14:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteSofa);
-                    break;
-                default:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GraniteTable);
-                    break;
-            }
-
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Granite, Main.rand.Next(25, 76));
-           
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Granite, 1, 25, 75));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.NightVisionHelmet, 20));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.GraniteBathtub, ItemID.GraniteBed, ItemID.GraniteBookcase, ItemID.GraniteCandelabra, ItemID.GraniteCandle, ItemID.GraniteChair, ItemID.GraniteChandelier, ItemID.GraniteChest, ItemID.GraniteClock, ItemID.GraniteDresser, ItemID.GraniteLamp, ItemID.GraniteLantern, ItemID.GranitePiano, ItemID.GraniteSink, ItemID.GraniteSofa, ItemID.GraniteTable));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(5, ItemID.GraniteGolemStatue, ItemID.WomanStatue, ItemID.SkeletonStatue));
         }
     }
 }

--- a/Items/Crates/HallowedCrate.cs
+++ b/Items/Crates/HallowedCrate.cs
@@ -1,7 +1,9 @@
-﻿using Terraria.ModLoader;
+﻿using System;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -16,74 +18,36 @@ namespace UnuBattleRodsR.Items.Crates
         public override void SetDefaults()
         {
             base.SetDefaults();
-           // AddTooltip("Right-click to open.");
+            // AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("HallowedCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(2500) == 0 && Main.hardMode && NPC.downedPlantBoss)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.RainbowGun);
-            }
+            itemLoot.Add(new OneFromWeightedRulesRule(1,
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.CrystalShard, 1, 4, 12), 2.0),
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.PixieDust, 1, 4, 12), 2.0),
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.UnicornHorn, 1, 2, 5), 1.0)
+            ));
 
-            if (Main.hardMode && Main.rand.Next(25) == 0)
-            {
-                switch (Main.rand.Next(5))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FlyingKnife);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CrystalVileShard);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DaedalusStormbow);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BlessedApple);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.IlluminantHook);
-                        break;
-                }
-            }
+            IItemDropRule hardmodeRule = new LeadingConditionRule(new Conditions.IsHardmode());
+            hardmodeRule.OnSuccess(ItemDropRule.ByCondition(new Conditions.DownedPlantera(), ItemID.RainbowGun, 2500));
+            hardmodeRule.OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(25, ItemID.FlyingKnife, ItemID.CrystalVileShard, ItemID.DaedalusStormbow, ItemID.BlessedApple, ItemID.IlluminantHook));
+            itemLoot.Add(hardmodeRule);
 
-            switch (Main.rand.Next(5))
+            IItemDropRule postMechRule = new LeadingConditionRule(new Conditions.BeatAnyMechBoss());
+            postMechRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.HallowedBar, 1, 2, 12));
+            if (ModLoader.TryGetMod("ThoriumMod", out Mod thoriumMod) && thoriumMod.TryFind("StrangePlating", out ModItem strangePlating) && thoriumMod.TryFind("LifeCell", out ModItem lifeCell))
             {
-                case 0:
-                case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CrystalShard, Main.rand.Next(4,13));
-                    break;
-                case 2:
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PixieDust, Main.rand.Next(4, 13));
-                    break;
-                default:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.UnicornHorn, Main.rand.Next(2, 6));
-                    break;
+                postMechRule.OnSuccess(new OneFromRulesRule(10,
+                    ItemDropRule.NotScalingWithLuck(strangePlating.Type, 1, 2, 6),
+                    ItemDropRule.NotScalingWithLuck(lifeCell.Type, 1, 1, 3)
+                ));
             }
-
-            if (NPC.downedMechBossAny)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.HallowedBar, Main.rand.Next(2, 13));
-                if (UnuBattleRodsR.thoriumPresent && Main.rand.Next(10) == 1)
-                {
-                    if(Main.rand.Next(2) == 1)
-                    {
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),UnuBattleRodsR.getItemTypeFromTag("ThoriumMod:StrangePlating"), Main.rand.Next(2, 7));
-                    }
-                    else
-                    {
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),UnuBattleRodsR.getItemTypeFromTag("ThoriumMod:LifeCell"), Main.rand.Next(1, 4));
-                    }
-                }
-            }
-            
-            base.RightClick(player);
+            itemLoot.Add(postMechRule);
         }
     }
 }

--- a/Items/Crates/LihzahrdCrate.cs
+++ b/Items/Crates/LihzahrdCrate.cs
@@ -1,7 +1,9 @@
-﻿using Terraria.ModLoader;
+﻿using System.Linq;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -17,123 +19,29 @@ namespace UnuBattleRodsR.Items.Crates
         public override void SetDefaults()
         {
             base.SetDefaults();
-           // AddTooltip("Right-click to open.");
+            // AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("LihzahrdCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(2500) == 0 && Main.hardMode && NPC.downedGolemBoss)
-            {
-                switch (Main.rand.Next(8))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Stynger);
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.StyngerBolt, Main.rand.Next(60, 100));
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.GolemFist);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.EyeoftheGolem);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.StaffofEarth);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.PossessedHatchet);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.HeatRay);
-                        break;
-                    case 6:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.SunStone);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Picksaw);
-                        break;
-                }
-            }
-            if (Main.rand.Next(100) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdAltar);
-            }
-            if (Main.rand.Next(20) == 0)
-            {
-                switch (Main.rand.Next(3))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdFurnace);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdPowerCell);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.SolarTablet);
-                        break;
-                }
-            }
-            switch (Main.rand.Next(17))
-            {
-                case 0:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdBathtub);
-                    break;
-                case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdBed);
-                    break;
-                case 2:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdBookcase);
-                    break;
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdCandelabra);
-                    break;
-                case 4:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdCandle);
-                    break;
-                case 5:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdChair);
-                    break;
-                case 6:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdChandelier);
-                    break;
-                case 7:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdChest);
-                    break;
-                case 8:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdClock);
-                    break;
-                case 9:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdDresser);
-                    break;
-                case 10:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdLamp);
-                    break;
-                case 11:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdLantern);
-                    break;
-                case 12:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdPiano);
-                    break;
-                case 13:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdSink);
-                    break;
-                case 14:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdSofa);
-                    break;
-                case 15:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.ToiletLihzhard);
-                    break;
-                default:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LihzahrdTable);
-                    break;
-            }
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.LihzahrdBrick, 1, 10, 25));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.LihzahrdAltar, 100));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(20, ItemID.LihzahrdFurnace, ItemID.LihzahrdPowerCell, ItemID.SolarTablet));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.LihzahrdBathtub, ItemID.LihzahrdBed, ItemID.LihzahrdBookcase, ItemID.LihzahrdCandelabra, ItemID.LihzahrdCandle, ItemID.LihzahrdChair, ItemID.LihzahrdChandelier, ItemID.LihzahrdChest, ItemID.LihzahrdClock, ItemID.LihzahrdDresser, ItemID.LihzahrdLamp, ItemID.LihzahrdLantern, ItemID.LihzahrdPiano, ItemID.LihzahrdSink, ItemID.LihzahrdSofa, ItemID.ToiletLihzhard, ItemID.LihzahrdTable));
 
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.LihzahrdBrick, Main.rand.Next(10, 26));
-           
-            base.RightClick(player);
+            IItemDropRule styngerRule = ItemDropRule.NotScalingWithLuck(ItemID.Stynger);
+            styngerRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.StyngerBolt, 1, 60, 100), hideLootReport: true);
+            int[] golemDrops = [ItemID.GolemFist, ItemID.EyeoftheGolem, ItemID.StaffofEarth, ItemID.PossessedHatchet, ItemID.HeatRay, ItemID.SunStone, ItemID.Picksaw];
+            IItemDropRule postGolemRule = new LeadingConditionRule(new DownedGolemItemDropCondition())
+                .OnSuccess(new LeadingConditionRule(new Conditions.IsHardmode()));
+            postGolemRule.OnSuccess(new OneFromRulesRule(10,
+                [styngerRule, .. golemDrops.Select(type => ItemDropRule.NotScalingWithLuck(type))]
+            ));
+            itemLoot.Add(postGolemRule);
         }
     }
 }

--- a/Items/Crates/LuminiteCrate.cs
+++ b/Items/Crates/LuminiteCrate.cs
@@ -1,8 +1,10 @@
-﻿using Terraria.ModLoader;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using System.Collections.Generic;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -20,89 +22,57 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("LuminiteCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if (NPC.downedMoonlord)
+            base.ModifyItemLoot(itemLoot);
+
+            itemLoot.Add(new OneFromRulesRule(1, GetFragmentRules()));
+
+            IItemDropRule postMoonLordRule = new LeadingConditionRule(new DownedMoonLordItemDropCondition());
+            postMoonLordRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.LunarOre, 1, 4, 24));
+            postMoonLordRule.OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(25, ItemID.Meowmere, ItemID.Terrarian, ItemID.StarWrath, ItemID.LastPrism, ItemID.LunarFlareBook, ItemID.SDMG, ItemID.FireworksLauncher, ItemID.MoonlordTurretStaff, ItemID.RainbowCrystalStaff));
+            postMoonLordRule.OnSuccess(new OneFromRulesRule(3,
+                ItemDropRule.NotScalingWithLuck(ItemID.MoonlordArrow, 1, 10, 50),
+                ItemDropRule.NotScalingWithLuck(ItemID.MoonlordBullet, 1, 10, 50)
+            ));
+
+            itemLoot.Add(postMoonLordRule);
+        }
+
+        private static IItemDropRule[] GetFragmentRules()
+        {
+            List<int> fragments = [ItemID.FragmentSolar, ItemID.FragmentVortex, ItemID.FragmentNebula, ItemID.FragmentStardust];
+
+            void AddToListIfExistsInMod(Mod mod, string name)
             {
-                if (Main.rand.Next(25) == 0)
+                if (mod.TryFind(name, out ModItem item))
                 {
-                    switch (Main.rand.Next(9))
-                    {
-                        case 0:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Meowmere);
-                            break;
-                        case 1:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Terrarian);
-                            break;
-                        case 2:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.StarWrath);
-                            break;
-                        case 3:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LastPrism);
-                            break;
-                        case 4:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LunarFlareBook);
-                            break;
-                        case 5:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.SDMG);
-                            break;
-                        case 6:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.FireworksLauncher);
-                            break;
-                        case 7:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.MoonlordTurretStaff);
-                            break;
-                        default:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.RainbowCrystalStaff);
-                            break;
-                    }
+                    fragments.Add(item.Type);
                 }
-
-                if (Main.rand.Next(3) == 0)
-                {
-                    if (Main.rand.Next(2) == 0)
-                    {
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.MoonlordBullet, Main.rand.Next(10, 51));
-                    }
-                    else
-                    {
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.MoonlordArrow, Main.rand.Next(10, 51));
-                    }
-                }
-
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.LunarOre, Main.rand.Next(4, 25));
             }
-            List<int> possibleFragments = new List<int>();
-            possibleFragments.Add(ItemID.FragmentSolar);
-            possibleFragments.Add(ItemID.FragmentNebula);
-            possibleFragments.Add(ItemID.FragmentStardust);
-            possibleFragments.Add(ItemID.FragmentVortex);
 
-            if (UnuBattleRodsR.thoriumPresent)
+            if (ModLoader.TryGetMod("ThoriumMod", out Mod thoriumMod))
             {
-                possibleFragments.Add(UnuBattleRodsR.getItemTypeFromTag("ThoriumMod:CelestialFragment"));
-                possibleFragments.Add(UnuBattleRodsR.getItemTypeFromTag("ThoriumMod:WhiteDwarfFragment"));
-                possibleFragments.Add(UnuBattleRodsR.getItemTypeFromTag("ThoriumMod:CometFragment"));
+                AddToListIfExistsInMod(thoriumMod, "CelestialFragment");
+                AddToListIfExistsInMod(thoriumMod, "WhiteDwarfFragment");
+                AddToListIfExistsInMod(thoriumMod, "CometFragment");
             }
-            if(ModLoader.TryGetMod("DBZMOD", out _))
+            if (ModLoader.TryGetMod("DBZMOD", out Mod dbzMod))
             {
-                possibleFragments.Add(UnuBattleRodsR.getItemTypeFromTag("DBZMOD:RadiantFragment"));
+                AddToListIfExistsInMod(dbzMod, "RadiantFragment");
             }
-            if (ModLoader.TryGetMod("SacredTools", out _))
+            if (ModLoader.TryGetMod("SacredTools", out Mod sacredTools))
             {
-                possibleFragments.Add(UnuBattleRodsR.getItemTypeFromTag("SacredTools:FragmentNova"));
+                AddToListIfExistsInMod(sacredTools, "FragmentNova");
             }
-            if (ModLoader.TryGetMod("ExpandedSentries", out _))
+            if (ModLoader.TryGetMod("ExpandedSentries", out Mod expandedSentries))
             {
-                possibleFragments.Add(UnuBattleRodsR.getItemTypeFromTag("ExpandedSentries:EclipseFragment"));
+                AddToListIfExistsInMod(expandedSentries, "EclipseFragment");
             }
 
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),possibleFragments[Main.rand.Next(possibleFragments.Count)] , Main.rand.Next(2, 21));
-
-            base.RightClick(player);
+            return fragments.Select(type => ItemDropRule.NotScalingWithLuck(type, 1, 2, 20)).ToArray();
         }
     }
 }

--- a/Items/Crates/MarbleCrate.cs
+++ b/Items/Crates/MarbleCrate.cs
@@ -1,7 +1,7 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -16,95 +16,20 @@ namespace UnuBattleRodsR.Items.Crates
         public override void SetDefaults()
         {
             base.SetDefaults();
-           // AddTooltip("Right-click to open.");
+            // AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("MarbleCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if(Main.rand.Next(20) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PocketMirror);
-            }
-            if (Main.rand.Next(20) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MedusaHead);
-            }
-
-            if (Main.rand.Next(5) == 0)
-            {
-                switch (Main.rand.Next(3))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.HopliteStatue);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MedusaStatue);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SkeletonStatue);
-                        break;
-                }
-            }
-
-            switch (Main.rand.Next(16))
-            {
-                case 0:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleBathtub);
-                    break;
-                case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleBed);
-                    break;
-                case 2:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleBookcase);
-                    break;
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleCandelabra);
-                    break;
-                case 4:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleCandle);
-                    break;
-                case 5:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleChair);
-                    break;
-                case 6:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleChandelier);
-                    break;
-                case 7:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleChest);
-                    break;
-                case 8:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleClock);
-                    break;
-                case 9:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleDresser);
-                    break;
-                case 10:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleLamp);
-                    break;
-                case 11:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleLantern);
-                    break;
-                case 12:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarblePiano);
-                    break;
-                case 13:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleSink);
-                    break;
-                case 14:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleSofa);
-                    break;
-                default:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MarbleTable);
-                    break;
-            }
-
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Marble, Main.rand.Next(25, 76));
-           
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Marble, 1, 25, 75));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.PocketMirror, 20));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.MedusaHead, 20));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(5, ItemID.HopliteStatue, ItemID.MedusaStatue, ItemID.SkeletonStatue));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.MarbleBathtub, ItemID.MarbleBed, ItemID.MarbleBookcase, ItemID.MarbleCandelabra, ItemID.MarbleCandle, ItemID.MarbleChair, ItemID.MarbleChandelier, ItemID.MarbleChest, ItemID.MarbleClock, ItemID.MarbleDresser, ItemID.MarbleLamp, ItemID.MarbleLantern, ItemID.MarblePiano, ItemID.MarbleSink, ItemID.MarbleSofa, ItemID.MarbleTable));
         }
     }
 }

--- a/Items/Crates/MeteorCrate.cs
+++ b/Items/Crates/MeteorCrate.cs
@@ -1,7 +1,7 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -16,91 +16,18 @@ namespace UnuBattleRodsR.Items.Crates
         public override void SetDefaults()
         {
             base.SetDefaults();
-           // AddTooltip("Right-click to open.");
+            // AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("MeteorCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            /*if(Main.rand.Next(25) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),);
-            }*/
-            
-
-            if (Main.rand.Next(5) == 0)
-            {
-                switch (Main.rand.Next(3))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.KingStatue);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.HeartStatue);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SkeletonStatue);
-                        break;
-                }
-            }
-
-            switch (Main.rand.Next(16))
-            {
-                case 0:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteBathtub);
-                    break;
-                case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteBed);
-                    break;
-                case 2:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteBookcase);
-                    break;
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteCandelabra);
-                    break;
-                case 4:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteCandle);
-                    break;
-                case 5:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteChair);
-                    break;
-                case 6:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteChandelier);
-                    break;
-                case 7:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteChest);
-                    break;
-                case 8:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteClock);
-                    break;
-                case 9:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteDresser);
-                    break;
-                case 10:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteLamp);
-                    break;
-                case 11:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteLantern);
-                    break;
-                case 12:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoritePiano);
-                    break;
-                case 13:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteSink);
-                    break;
-                case 14:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteSofa);
-                    break;
-                default:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MeteoriteTable);
-                    break;
-            }
-
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Meteorite, Main.rand.Next(15, 36));
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Meteorite, 1, 15, 35));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(5, ItemID.KingStatue, ItemID.HeartStatue, ItemID.SkeletonStatue));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.MeteoriteBathtub, ItemID.MeteoriteBed, ItemID.MeteoriteBookcase, ItemID.MeteoriteCandelabra, ItemID.MeteoriteCandle, ItemID.MeteoriteChair, ItemID.MeteoriteChandelier, ItemID.MeteoriteChest, ItemID.MeteoriteClock, ItemID.MeteoriteDresser, ItemID.MeteoriteLamp, ItemID.MeteoriteLantern, ItemID.MeteoritePiano, ItemID.MeteoriteSink, ItemID.MeteoriteSofa, ItemID.MeteoriteTable));
         }
     }
 }

--- a/Items/Crates/MimicCrate.cs
+++ b/Items/Crates/MimicCrate.cs
@@ -1,7 +1,6 @@
-﻿using Terraria.ModLoader;
-using Terraria;
-using Terraria.ID;
-using UnuBattleRodsR.Players;
+﻿using Terraria;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 using UnuBattleRodsR.NPCs;
 
 namespace UnuBattleRodsR.Items.Crates
@@ -20,25 +19,14 @@ namespace UnuBattleRodsR.Items.Crates
             base.SetDefaults();
             Item.value = 0;
             Item.createTile = Mod.Find<ModTile>("MimicCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if (Main.netMode != NetmodeID.MultiplayerClient)
-            {
-                NPC.NewNPC(player.GetSource_ItemUse(Item), (int)player.Center.X, (int)player.Center.Y, ModContent.NPCType<CrateMimic>());
-            }
-            else
-            {
-                ModPacket req = Mod.GetPacket();
-                req.Write((byte)UnuBattleRodsR.Message.SummonNPC);
-                req.Write((int)ModContent.NPCType<CrateMimic>());
-                req.Write((int)player.Center.X);
-                req.Write((int)player.Center.Y);
-                req.Write((int)Item.type);
-                req.Send();
-            }
+            // Do not drop normal crate loot.
+            //base.ModifyItemLoot(itemLoot);
+
+            itemLoot.Add(new DropNPCRule(ModContent.NPCType<CrateMimic>(), 1));
         }
     }
 }

--- a/Items/Crates/ObsidianCrate.cs
+++ b/Items/Crates/ObsidianCrate.cs
@@ -1,7 +1,8 @@
-﻿using Terraria.ModLoader;
-using Terraria;
-using Terraria.ID;
+﻿using Terraria;
 using Terraria.DataStructures;
+using Terraria.GameContent.ItemDropRules;
+using Terraria.ID;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -12,98 +13,25 @@ namespace UnuBattleRodsR.Items.Crates
             // DisplayName.SetDefault("Obsidian Crate");
             base.SetStaticDefaults(); Item.ResearchUnlockCount = 10;
         }
+
         public override void SetDefaults()
         {
             base.SetDefaults();
-           // AddTooltip("Right-click to open.");
+            // AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("ObsidianCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(40) == 0 || (!Main.hardMode && Main.rand.Next(10) == 0))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GuideVoodooDoll);
-            }
-            
-
-            if (Main.rand.Next(5) == 0)
-            {
-                switch (Main.rand.Next(3))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.QueenStatue);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.StarStatue);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SkeletonStatue);
-                        break;
-                }
-            }
-
-            switch (Main.rand.Next(17))
-            {
-                case 0:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianBathtub);
-                    break;
-                case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianBed);
-                    break;
-                case 2:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianBookcase);
-                    break;
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianCandelabra);
-                    break;
-                case 4:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianCandle);
-                    break;
-                case 5:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianChair);
-                    break;
-                case 6:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianChandelier);
-                    break;
-                case 7:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianChest);
-                    break;
-                case 8:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianClock);
-                    break;
-                case 9:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianDresser);
-                    break;
-                case 10:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianLamp);
-                    break;
-                case 11:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianLantern);
-                    break;
-                case 12:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianPiano);
-                    break;
-                case 13:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianSink);
-                    break;
-                case 14:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianSofa);
-                    break;
-                case 15:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.ToiletObsidian);
-                    break;
-                default:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ObsidianTable);
-                    break;
-            }
-
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Obsidian, Main.rand.Next(25, 76));
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Hellstone, Main.rand.Next(5, 26));
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Obsidian, 1, 25, 75));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Hellstone, 1, 5, 25));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.ObsidianBathtub, ItemID.ObsidianBed, ItemID.ObsidianBookcase, ItemID.ObsidianCandelabra, ItemID.ObsidianCandle, ItemID.ObsidianChair, ItemID.ObsidianChandelier, ItemID.ObsidianChest, ItemID.ObsidianClock, ItemID.ObsidianDresser, ItemID.ObsidianLamp, ItemID.ObsidianLantern, ItemID.ObsidianPiano, ItemID.ObsidianSink, ItemID.ObsidianSofa, ItemID.ToiletObsidian, ItemID.ObsidianTable));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(5, ItemID.QueenStatue, ItemID.StarStatue, ItemID.SkeletonStatue));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.GuideVoodooDoll, 40))
+                .OnFailedRoll(ItemDropRule.ByCondition(new Conditions.IsPreHardmode(), ItemID.GuideVoodooDoll, 10));
         }
     }
 }

--- a/Items/Crates/OldOnesCrate.cs
+++ b/Items/Crates/OldOnesCrate.cs
@@ -1,13 +1,14 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
+using UnuBattleRodsR.Items.Materials;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class OldOnesCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Old One's Crate");
@@ -20,92 +21,22 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("OldOnesCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if (NPC.downedGolemBoss)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),Mod.Find<ModItem>("BetsyScales").Type, Main.rand.Next(1,4));
-            }
-            if (Main.rand.Next(10) == 0 && Main.hardMode)
-            {
-                switch (Main.rand.Next(4))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.WarTable, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.WarTableBanner, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DD2PetDragon, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DD2PetGato, 1);
-                        break;
-                }
-            }
-            if (Main.rand.Next(10) == 0 && NPC.downedMechBossAny)
-            {
-                switch (Main.rand.Next(10))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ApprenticeScarf, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SquireShield, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.HuntressBuckler, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MonkBelt, 1);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3852, 1);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DD2PhoenixBow, 1);
-                        break;
-                    case 6:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3823, 1);
-                        break;
-                    case 7:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3835, 1);
-                        break;
-                    case 8:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3836, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3856, 1);
-                        break;
-                }
-            }
-            if (Main.rand.Next(10) == 0 && NPC.downedGolemBoss)
-            {
-                switch (Main.rand.Next(6))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3827, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3858, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3859, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3870, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BetsyWings, 1);
-                        break;
-                }
+            base.ModifyItemLoot(itemLoot);
 
-            }
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.ByCondition(new DownedGolemItemDropCondition(), ModContent.ItemType<BetsyScales>(), 1, 1, 3));
+
+            itemLoot.Add(new LeadingConditionRule(new Conditions.BeatAnyMechBoss()))
+                .OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(10, ItemID.ApprenticeScarf, ItemID.SquireShield, ItemID.HuntressBuckler, ItemID.MonkBelt, ItemID.BookStaff, ItemID.DD2PhoenixBow, ItemID.DD2SquireDemonSword, ItemID.MonkStaffT1, ItemID.MonkStaffT2, ItemID.DD2PetGhost));
+
+            itemLoot.Add(new LeadingConditionRule(new DownedGolemItemDropCondition()))
+                .OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(10, ItemID.DD2SquireBetsySword, ItemID.MonkStaffT3, ItemID.DD2BetsyBow, ItemID.ApprenticeStaffT3, ItemID.BetsyWings));
+
+            itemLoot.Add(new LeadingConditionRule(new Conditions.IsHardmode()))
+                .OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(10, ItemID.WarTable, ItemID.WarTableBanner, ItemID.DD2PetDragon, ItemID.DD2PetGato));
         }
     }
 }

--- a/Items/Crates/SandstormCrate.cs
+++ b/Items/Crates/SandstormCrate.cs
@@ -1,13 +1,12 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class SandstormCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Sandstorm Crate");
@@ -20,31 +19,18 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("SandstormCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.AntlionMandible, Main.rand.Next (1,6));
-            }
-            if (Main.rand.Next(13) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3772, 1);
-            }
-            if (Main.rand.Next(4) == 0 && Main.hardMode)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SharkFin, Main.rand.Next(1, 3));
-            }
-            if (Main.rand.Next(5) == 0 && Main.hardMode)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3783, Main.rand.Next(1, 6));
-            }
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SandBlock, Main.rand.Next(10, 50));
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Cactus, Main.rand.Next(5, 40));
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SandBlock, 1, 10, 50));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Cactus, 1, 5, 40));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.AntlionMandible, 3, 1, 5));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.AntlionClaw, 13));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.SharkFin, 4, 1, 2));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.AncientBattleArmorMaterial, 5, 1, 5));
         }
     }
 }

--- a/Items/Crates/ShroomiteCrate.cs
+++ b/Items/Crates/ShroomiteCrate.cs
@@ -1,7 +1,7 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -19,28 +19,19 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("ShroomiteCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ShroomiteBar, Main.rand.Next(3, 10));
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.Mushroom, Main.rand.Next(1, 4));
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.GlowingMushroom, Main.rand.Next(1, 4));
-            if (Main.rand.NextBool(5))
-            {
-                switch (Main.rand.Next(2))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.GreenMushroom, Main.rand.Next(1, 4));
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.TealMushroom, Main.rand.Next(1, 4));
-                        break;
-                }
-            }
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Mushroom, 1, 1, 3));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.GlowingMushroom, 1, 1, 3));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.ShroomiteBar, 1, 3, 9));
+            itemLoot.Add(new OneFromRulesRule(5,
+                ItemDropRule.NotScalingWithLuck(ItemID.GreenMushroom, 1, 1, 3),
+                ItemDropRule.NotScalingWithLuck(ItemID.TealMushroom, 1, 1, 3)
+            ));
         }
     }
 }

--- a/Items/Crates/SlimeCrate.cs
+++ b/Items/Crates/SlimeCrate.cs
@@ -1,13 +1,14 @@
-﻿using Terraria.ModLoader;
+﻿using System.Linq;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class SlimeCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Slime Crate");
@@ -20,126 +21,28 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("SlimeCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if (Main.rand.Next(10) == 0 && NPC.downedSlimeKing)
-            {
-                switch (Main.rand.Next(7))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Solidifier, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimySaddle, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.NinjaHood, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.NinjaShirt, 1);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.NinjaPants, 1);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeHook, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeGun, 1);
-                        break;
-                }
-            }
-            if (Main.rand.Next(5) == 0)
-            {
-                switch (Main.rand.Next(18))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimePlatform, Main.rand.Next (5,25) );
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeWorkBench, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeBathtub, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeBed, 1);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeBookcase, 1);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeCandelabra, 1);
-                        break;
-                    case 6:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeCandle, 1);
-                        break;
-                    case 7:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeChair, 1);
-                        break;
-                    case 8:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeChandelier, 1);
-                        break;
-                    case 9:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeChest, 1);
-                        break;
-                    case 10:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeClock, 1);
-                        break;
-                    case 11:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeDoor, 1);
-                        break;
-                    case 12:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeDresser, 1);
-                        break;
-                    case 13:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeLamp, 1);
-                        break;
-                    case 14:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeLantern, 1);
-                        break;
-                    case 15:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimePiano, 1);
-                        break;
-                    case 16:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeSofa, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeTable, 1);
-                        break;
-                }
+            base.ModifyItemLoot(itemLoot);
 
-            }
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Gel, 1, 20, 300));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.PinkGel, 10, 5, 50));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SlimeStaff, 50));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SlimeStatue, 25));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SlimeCrown, 8));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.BlendOMatic, 10));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.AsphaltBlock, 9, 5, 50));
 
-            if (Main.rand.Next(50) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeStaff, 1);
-            }
-            if (Main.rand.Next(25) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeStatue, 1);
-            }
-            if (Main.rand.Next(10) == 0 && Main.hardMode)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BlendOMatic, 1);
-            }
-            if (Main.rand.Next(9) == 0 && Main.hardMode)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.AsphaltBlock, Main.rand.Next(5, 50));
-            }
-            if (Main.rand.Next(10) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PinkGel, Main.rand.Next(5, 50));
-            }
-            if (Main.rand.Next(8) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SlimeCrown, 1);
-            }
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Gel, Main.rand.Next(20, 300));
-            base.RightClick(player);
+            itemLoot.Add(new LeadingConditionRule(new DownedKingSlimeItemDropCondition()))
+                .OnSuccess(ItemDropRule.OneFromOptionsNotScalingWithLuck(10, ItemID.Solidifier, ItemID.SlimySaddle, ItemID.NinjaHood, ItemID.NinjaShirt, ItemID.NinjaPants, ItemID.SlimeHook, ItemID.SlimeGun));
+
+            int[] furnitureTypes = [ItemID.SlimeWorkBench, ItemID.SlimeBanner, ItemID.SlimeBed, ItemID.SlimeBookcase, ItemID.SlimeCandelabra, ItemID.SlimeCandle, ItemID.SlimeChair, ItemID.SlimeChandelier, ItemID.SlimeChest, ItemID.SlimeClock, ItemID.SlimeDoor, ItemID.SlimeDresser, ItemID.SlimeLamp, ItemID.SlimeLantern, ItemID.SlimePiano, ItemID.SlimeSofa, ItemID.SlimeTable];
+
+            itemLoot.Add(new OneFromRulesRule(5, [
+                ItemDropRule.NotScalingWithLuck(ItemID.SlimePlatform, 1, 5, 25),
+                .. furnitureTypes.Select(type => ItemDropRule.NotScalingWithLuck(type, 1))]));
         }
     }
 }

--- a/Items/Crates/SnowstormCrate.cs
+++ b/Items/Crates/SnowstormCrate.cs
@@ -1,13 +1,12 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class SnowstormCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Snowstorm Crate");
@@ -20,51 +19,21 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("SnowstormCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if (Main.rand.Next(4) == 0)
-            {
-                switch (Main.rand.Next(2))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),1136, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),1135, 1);
-                        break;
-                }
-            }
-            if (Main.rand.Next(4) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.UmbrellaHat, 1);
-            }
-            if (Main.rand.Next(10) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.NimbusRod, 1);
-            }
-            if (Main.rand.Next(9) == 0 && Main.hardMode)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.RainbowBrick, Main.rand.Next(10,30));
-            }
-            if (Main.rand.Next(13) == 0 && Main.hardMode)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.IceFeather, 1);
-            }
-            if (Main.rand.Next(4) == 0 && Main.hardMode)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FrostCore, Main.rand.Next(1, 6));
-            }
-            if (Main.rand.Next(7) == 0 && Main.hardMode)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FrostStaff, 1);
-            }
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SnowBlock, Main.rand.Next(10, 50));
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Snowball, Main.rand.Next(5, 40));
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SnowBlock, 1, 10, 50));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Snowball, 1, 5, 40));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.UmbrellaHat, 4));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.NimbusRod, 10)); // what
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(4, ItemID.RainHat, ItemID.RainCoat));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.RainbowBrick, 9, 10, 30));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.IceFeather, 13));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.FrostCore, 4, 1, 5));
+            itemLoot.Add(ItemDropRule.ByCondition(new Conditions.IsHardmode(), ItemID.FrostStaff, 7));
         }
     }
 }

--- a/Items/Crates/SoulCrate.cs
+++ b/Items/Crates/SoulCrate.cs
@@ -1,9 +1,10 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using System;
-using Terraria.DataStructures;
-using Terraria.ModLoader.Config;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
+using UnuBattleRodsR.Items.Rods.HardMode;
+using UnuBattleRodsR.Items.Rods.PostMoonLord;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -21,105 +22,57 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("SoulCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if (!NPC.AnyNPCs(NPCID.Wizard) && !NPC.AnyNPCs(NPCID.BoundWizard))
+            base.ModifyItemLoot(itemLoot);
+
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SoulofLight, 1, 3, 15));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SoulofNight, 1, 3, 15));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SoulofFlight, 3, 3, 15));
+            itemLoot.Add(ItemDropRule.ByCondition(new DownedDestroyerDropCondition(), ItemID.SoulofMight, 3, 1, 8));
+            itemLoot.Add(ItemDropRule.ByCondition(new DownedTwinsDropCondition(), ItemID.SoulofSight, 3, 1, 8));
+            itemLoot.Add(ItemDropRule.ByCondition(new DownedSkeletronPrimeDropCondition(), ItemID.SoulofFright, 3, 1, 8));
+
+            IItemDropRule spectreRodRule = new LeadingConditionRule(new HasAnyItemsItemDropCondition(
+                ModContent.ItemType<SpectreBattlerod>(),
+                ModContent.ItemType<LifeforceBattlerod>(),
+                ModContent.ItemType<RodContainmentUnit>()
+            ));
+            spectreRodRule.OnSuccess(ItemDropRule.NotScalingWithLuck(ItemID.Ectoplasm, 1, 1, 4));
+
+            if (ModLoader.TryGetMod("CalamityMod", out Mod calamityMod))
             {
-                if (Main.rand.NextBool(5))
+                if (calamityMod.TryFind("EssenceofEleum", out ModItem essenceOfEleum)
+                    && calamityMod.TryFind("EssenceofHavoc", out ModItem essenceOfHavoc)
+                    && calamityMod.TryFind("EssenceofSunlight", out ModItem essenceOfSunlight))
                 {
-
-                    if (Main.netMode != NetmodeID.MultiplayerClient)
-                    {
-                        NPC.NewNPC(player.GetSource_ItemUse(Item), (int)player.Center.X, (int)player.Center.Y, NPCID.BoundWizard);
-                    }
-                    else
-                    {
-                        ModPacket req = Mod.GetPacket();
-                        req.Write((byte)UnuBattleRodsR.Message.SummonNPC);
-                        req.Write((int)NPCID.BoundWizard);
-                        req.Write((int)player.Center.X);
-                        req.Write((int)player.Center.Y);
-                        req.Write((int)Item.type);
-                        req.Send();
-                    }
+                    itemLoot.Add(new OneFromRulesRule(1,
+                        ItemDropRule.NotScalingWithLuck(essenceOfEleum.Type, 1, 1, 4),
+                        ItemDropRule.NotScalingWithLuck(essenceOfHavoc.Type, 1, 1, 4),
+                        ItemDropRule.NotScalingWithLuck(essenceOfSunlight.Type, 1, 1, 4)
+                    ));
                 }
-                else
+
+                if (calamityMod.TryFind("CoreofEleum", out ModItem coreOfEleum)
+                    && calamityMod.TryFind("CoreofHavoc", out ModItem coreOfHavoc)
+                    && calamityMod.TryFind("CoreofSunlight", out ModItem coreOfSunlight))
                 {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.WizardsHat);
+                    spectreRodRule.OnSuccess(new OneFromRulesRule(3,
+                        ItemDropRule.NotScalingWithLuck(coreOfEleum.Type, 1, 1, 4),
+                        ItemDropRule.NotScalingWithLuck(coreOfHavoc.Type, 1, 1, 4),
+                        ItemDropRule.NotScalingWithLuck(coreOfSunlight.Type, 1, 1, 4)
+                    ));
                 }
             }
 
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SoulofLight, Main.rand.Next(3, 16));
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SoulofNight, Main.rand.Next(3, 16));
+            itemLoot.Add(spectreRodRule);
 
-            if(Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SoulofFlight, Main.rand.Next(3, 16));
-            }
-            if (Main.rand.Next(3) == 0 && NPC.downedMechBoss1)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SoulofSight, Main.rand.Next(1, 9));
-            }
-            if (Main.rand.Next(3) == 0 && NPC.downedMechBoss2)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SoulofFright, Main.rand.Next(1, 9));
-            }
-            if (Main.rand.Next(3) == 0 && NPC.downedMechBoss3)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SoulofMight, Main.rand.Next(1, 9));
-            }
-
-            if (FindSpectreRod(player))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Ectoplasm, Main.rand.Next(1, 5));
-            }
-
-            if (ModLoader.TryGetMod("CalamityMod", out Mod calamity))
-            {
-                switch (Main.rand.Next(3)) {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), new ItemDefinition("CalamityMod", "EssenceofEleum").Type, Main.rand.Next(1, 5));
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), new ItemDefinition("CalamityMod", "EssenceofHavoc").Type, Main.rand.Next(1, 5));
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), new ItemDefinition("CalamityMod", "EssenceofSunlight").Type, Main.rand.Next(1, 5));
-                        break;
-                }
-                if (FindSpectreRod(player) && Main.rand.NextBool(3))
-                {
-                    switch (Main.rand.Next(3))
-                    {
-                        case 0:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), new ItemDefinition("CalamityMod", "CoreofEleum").Type, Main.rand.Next(1, 5));
-                            break;
-                        case 1:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), new ItemDefinition("CalamityMod", "CoreofHavoc").Type, Main.rand.Next(1, 5));
-                            break;
-                        default:
-                            player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), new ItemDefinition("CalamityMod", "CoreofSunlight").Type, Main.rand.Next(1, 5));
-                            break;
-                    }
-                }
-            }
-
-            base.RightClick(player);
-        }
-
-        private bool FindSpectreRod(Player player)
-        {
-           for(int i = 0; i< 50; i++)
-            {
-                if(player.inventory[i].type == Mod.Find<ModItem>("SpectreBattlerod").Type || player.inventory[i].type == Mod.Find<ModItem>("LifeforceBattlerod").Type || player.inventory[i].type == Mod.Find<ModItem>("RodContainmentUnit").Type)
-                {
-                    return true;
-                }
-            }
-            return false;
+            IItemDropRule wizardRule = new DropNPCRule(NPCID.BoundWizard, 5);
+            wizardRule.OnFailedRoll(ItemDropRule.NotScalingWithLuck(ItemID.WizardsHat));
+            itemLoot.Add(new LeadingConditionRule(new NoExistingNPCsItemDropCondition(NPCID.Wizard, NPCID.BoundWizard)))
+                .OnSuccess(wizardRule);
         }
     }
 }

--- a/Items/Crates/SpookyCrate.cs
+++ b/Items/Crates/SpookyCrate.cs
@@ -1,13 +1,12 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class SpookyCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Spooky Crate");
@@ -20,183 +19,23 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("SpookyCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if(Main.rand.Next(20) == 0)
-            {
-                switch (Main.rand.Next(12))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyTwig);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyHook);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CursedSapling);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.NecromanticScroll);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.StakeLauncher);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TheHorsemansBlade);
-                        break;
-                    case 6:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BatScepter);
-                        break;
-                    case 7:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BlackFairyDust);
-                        break;
-                    case 8:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpiderEgg);
-                        break;
-                    case 9:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.RavenStaff);
-                        break;
-                    case 10:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CandyCornRifle);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.JackOLanternLauncher);
-                        break;
-                }
-            }
-
-            if (Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Stake, Main.rand.Next(30, 61));
-
-            }
-            if (Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CandyCorn, Main.rand.Next(50, 101));
-
-            }
-            if (Main.rand.Next(3) == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ExplosiveJackOLantern, Main.rand.Next(25, 51));
-
-            }
-
-            if (Main.rand.Next(2) == 0)
-            {
-                switch (Main.rand.Next(16))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyBathtub);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyBed);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyBookcase);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyCandelabra);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyCandle);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyChair);
-                        break;
-                    case 6:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyChandelier);
-                        break;
-                    case 7:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyChest);
-                        break;
-                    case 8:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyClock);
-                        break;
-                    case 9:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyDresser);
-                        break;
-                    case 10:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyLamp);
-                        break;
-                    case 11:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyLantern);
-                        break;
-                    case 12:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyPiano);
-                        break;
-                    case 13:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookySink);
-                        break;
-                    case 14:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookySofa);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyTable);
-                        break;
-                }
-            }else
-            {
-                switch (Main.rand.Next(16))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinBathtub);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinBed);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinBookcase);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinCandelabra);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinCandle);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinChair);
-                        break;
-                    case 6:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinChandelier);
-                        break;
-                    case 7:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinChest);
-                        break;
-                    case 8:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinClock);
-                        break;
-                    case 9:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinDresser);
-                        break;
-                    case 10:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinLamp);
-                        break;
-                    case 11:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinLantern);
-                        break;
-                    case 12:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinPiano);
-                        break;
-                    case 13:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinSink);
-                        break;
-                    case 14:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinSofa);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PumpkinTable);
-                        break;
-                }
-            }
-
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyWood, Main.rand.Next(25, 76));
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Pumpkin, Main.rand.Next(25, 76));
-            player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoodieBag, Main.rand.Next(1, 5));
-            base.RightClick(player);
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.SpookyWood, 1, 25, 75));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Pumpkin, 1, 25, 75));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.GoodieBag, 1, 1, 4));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.Stake, 3, 30, 60));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.CandyCorn, 3, 50, 100));
+            itemLoot.Add(ItemDropRule.NotScalingWithLuck(ItemID.ExplosiveJackOLantern, 3, 25, 50));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(20, ItemID.SpookyTwig, ItemID.SpookyHook, ItemID.CursedSapling, ItemID.NecromanticScroll, ItemID.StakeLauncher, ItemID.TheHorsemansBlade, ItemID.BatScepter, ItemID.BlackFairyDust, ItemID.SpiderEgg, ItemID.RavenStaff, ItemID.CandyCornRifle, ItemID.JackOLanternLauncher));
+            itemLoot.Add(new OneFromRulesRule(1,
+                ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.PumpkinBathtub, ItemID.PumpkinBed, ItemID.PumpkinBookcase, ItemID.PumpkinCandelabra, ItemID.PumpkinCandle, ItemID.PumpkinChair, ItemID.PumpkinChandelier, ItemID.PumpkinChest, ItemID.PumpkinClock, ItemID.PumpkinDresser, ItemID.PumpkinLamp, ItemID.PumpkinLantern, ItemID.PumpkinPiano, ItemID.PumpkinSink, ItemID.PumpkinSofa, ItemID.PumpkinTable),
+                ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.SpookyBathtub, ItemID.SpookyBed, ItemID.SpookyBookcase, ItemID.SpookyCandelabra, ItemID.SpookyCandle, ItemID.SpookyChair, ItemID.SpookyChandelier, ItemID.SpookyChest, ItemID.SpookyClock, ItemID.SpookyDresser, ItemID.SpookyLamp, ItemID.SpookyLantern, ItemID.SpookyPiano, ItemID.SpookySink, ItemID.SpookySofa, ItemID.SpookyTable)
+            ));
         }
     }
 }

--- a/Items/Crates/TerraCrate.cs
+++ b/Items/Crates/TerraCrate.cs
@@ -1,14 +1,14 @@
-﻿using Terraria.ModLoader;
+﻿using System;
 using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using System.Collections.Generic;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class TerraCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Terra Crate");
@@ -21,40 +21,21 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("TerraCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
+            base.ModifyItemLoot(itemLoot);
 
-            if(Main.rand.Next(20) == 0)
-            {
-                List<int> possibleBrokens = new List<int>();
-                possibleBrokens.Add(ItemID.BrokenHeroSword);
-                /*     if (UnuBattleRodsR.thoriumPresent)
-                     {
-                         int bhf = UnuBattleRodsR.getItemTypeFromTag("ThoriumMod:BrokenHeroFragment");
-                         possibleBrokens.Add(bhf);
-                         possibleBrokens.Add(bhf);
-                         possibleBrokens.Add(bhf);
-                     }
-                     if (ModLoader.GetMod("ExpandedSentries") != null)
-                     {
-                         int bhs = UnuBattleRodsR.getItemTypeFromTag("ExpandedSentries:BrokenSentryParts");
-                         possibleBrokens.Add(bhs);
-                         possibleBrokens.Add(bhs);
-                     }*/
-                if (Main.rand.NextBool(8))
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), ItemID.TerraToilet, 1);
-                }
-                else
-                {
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), possibleBrokens[Main.rand.Next(possibleBrokens.Count)], 1);
-                }
-            }
-            
-            base.RightClick(player);
+            // Using OneFromWeightedRulesRule to facilitate adding weights later, unsure if the commented-out code for other mods' broken items was removed intentionally.
+            IItemDropRule brokenHeroRule = new OneFromWeightedRulesRule(1,
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.BrokenHeroSword), 1.0)
+            );
+
+            itemLoot.Add(new OneFromWeightedRulesRule(20,
+                new Tuple<IItemDropRule, double>(ItemDropRule.NotScalingWithLuck(ItemID.TerraToilet), 1.0),
+                new Tuple<IItemDropRule, double>(brokenHeroRule, 7.0)
+            ));
         }
     }
 }

--- a/Items/Crates/TheCratestCrate.cs
+++ b/Items/Crates/TheCratestCrate.cs
@@ -1,12 +1,8 @@
-﻿using System.Collections.Generic;
-using Terraria.ModLoader;
+﻿using System.Linq;
 using Terraria;
-using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 using UnuBattleRodsR.Players;
-using Terraria.Localization;
-using System;
-using rail;
 
 namespace UnuBattleRodsR.Items.Crates
 {
@@ -22,58 +18,22 @@ namespace UnuBattleRodsR.Items.Crates
         public override void SetDefaults()
         {
             base.SetDefaults();
-           // AddTooltip("Right-click to open.");
+            // AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("TheCratestCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override bool CanRightClick()
         {
-            if (player.whoAmI != Main.myPlayer)
-            {
-                return;
-            }
-            List<string> crateKeys = new List<string>();
-            crateKeys.AddRange(player.GetModPlayer<FishPlayer>().fishedCrates.Keys);
-            if(crateKeys.Count == 0 || (crateKeys.Count == 1 && crateKeys[0].Equals(this.FullName)))
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), Type, 1);
-                Main.NewText(Language.GetOrRegister("Mods.UnuBattleRodsR.Crate.Unable").Value, 255, 255, 0);
-                return;
-            }
-            int tries = 0;
-            int provided = 0;
-            while (tries < 10 && provided < 4)
-            {
-                string crate = crateKeys[Main.rand.Next(0, crateKeys.Count)];
-                if (!crate.Equals(this.FullName)){
-                    if (Int32.TryParse(crate, out int cid))
-                    {
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), cid, Main.rand.Next(1, 5));
-                        provided++;
-                    }
-                    else
-                    {
-                        foreach (Item itm in ContentSamples.ItemsByType.Values)
-                        {
-                            if (itm.ModItem != null && itm.ModItem.FullName.Equals(crate))
-                            {
-                                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), itm.type, Main.rand.Next(1, 5));
-                                provided++;
-                                break;
-                            }
-                        }
-                    }
-                }
-                tries++;
-            }
-            if (provided == 0)
-            {
-                player.QuickSpawnItem(new EntitySource_ItemOpen(player, Type, "crate"), Type, 1);
-                Main.NewText(Language.GetOrRegister("Mods.UnuBattleRodsR.Crate.Unable").Value, 255, 255, 0);
-            }
-            return;
+            return Main.LocalPlayer.GetModPlayer<FishPlayer>().fishedCrates.Keys.Any(key => key != FullName) && base.CanRightClick();
+        }
+
+        public override void ModifyItemLoot(ItemLoot itemLoot)
+        {
+            // Do not drop normal crate loot
+            //base.ModifyItemLoot(itemLoot);
+
+            itemLoot.Add(new CratestCrateItemDropRule());
         }
     }
 }

--- a/Items/Crates/TreasureCrate.cs
+++ b/Items/Crates/TreasureCrate.cs
@@ -1,13 +1,12 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class TreasureCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Treasure Crate");
@@ -20,123 +19,15 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("TreasureCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            if (Main.rand.Next(15) == 0)
-            {
-                switch (Main.rand.Next(5))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CoinGun, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Cutlass, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldRing, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.LuckyCoin, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.PirateStaff, 1);
-                        break;
-                }
-            }
-            if (Main.rand.Next(7) == 0)
-            {
-                switch (Main.rand.Next(7))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.EyePatch, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SailorHat, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SailorShirt, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SailorPants, 1);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BuccaneerBandana, 1);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BuccaneerShirt, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BuccaneerPants, 1);
-                        break;
-                }
-            }
-            if (Main.rand.Next(3) == 0)
-            {
-                switch (Main.rand.Next(19))
-                {
-                    case 0:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenBathtub, 1);
-                        break;
-                    case 1:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenBed, 1);
-                        break;
-                    case 2:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenBookcase, 1);
-                        break;
-                    case 3:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenCandelabra, 1);
-                        break;
-                    case 4:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenCandle, 1);
-                        break;
-                    case 5:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenChair, 1);
-                        break;
-                    case 6:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenChest, 1);
-                        break;
-                    case 7:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenDoor, 1);
-                        break;
-                    case 8:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenDresser, 1);
-                        break;
-                    case 9:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenClock, 1);
-                        break;
-                    case 10:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenLamp, 1);
-                        break;
-                    case 11:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenLantern, 1);
-                        break;
-                    case 12:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenPiano, 1);
-                        break;
-                    case 13:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenPlatform, 1);
-                        break;
-                    case 14:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenSink, 1);
-                        break;
-                    case 15:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenSofa, 1);
-                        break;
-                    case 16:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenTable, 1);
-                        break;
-                    case 17:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenToilet, 1);
-                        break;
-                    default:
-                        player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.GoldenWorkbench, 1);
-                        break;
-                }
-            }
-            base.RightClick(player);
+            base.ModifyItemLoot(itemLoot);
+
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(7, ItemID.EyePatch, ItemID.SailorHat, ItemID.SailorShirt, ItemID.SailorPants, ItemID.BuccaneerBandana, ItemID.BuccaneerShirt, ItemID.BuccaneerPants));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(15, ItemID.CoinGun, ItemID.Cutlass, ItemID.GoldRing, ItemID.LuckyCoin, ItemID.PirateStaff));
+            itemLoot.Add(ItemDropRule.OneFromOptionsNotScalingWithLuck(3, ItemID.GoldenBathtub, ItemID.GoldenBed, ItemID.GoldenBookcase, ItemID.GoldenCandelabra, ItemID.GoldenCandle, ItemID.GoldenChair, ItemID.GoldenChest, ItemID.GoldenDoor, ItemID.GoldenDresser, ItemID.GoldenClock, ItemID.GoldenLamp, ItemID.GoldenLantern, ItemID.GoldenPiano, ItemID.GoldenPlatform, ItemID.GoldenSink, ItemID.GoldenSofa, ItemID.GoldenTable, ItemID.GoldenToilet, ItemID.GoldenWorkbench));
         }
     }
 }

--- a/Items/Crates/WingCrate.cs
+++ b/Items/Crates/WingCrate.cs
@@ -1,13 +1,13 @@
-﻿using Terraria.ModLoader;
-using Terraria;
+﻿using Terraria;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
-using Terraria.DataStructures;
+using Terraria.ModLoader;
+using UnuBattleRodsR.ItemDrops;
 
 namespace UnuBattleRodsR.Items.Crates
 {
     public class WingCrate : Crate
     {
-
         public override void SetStaticDefaults()
         {
             // DisplayName.SetDefault("Wing Crate");
@@ -20,146 +20,14 @@ namespace UnuBattleRodsR.Items.Crates
             //AddTooltip("Right-click to open.");
             Item.value = Item.sellPrice(0, 1, 0, 0);
             Item.createTile = Mod.Find<ModTile>("WingCrate").Type;
-
         }
 
-        public override void RightClick(Player player)
+        public override void ModifyItemLoot(ItemLoot itemLoot)
         {
-            int wingcount = Main.rand.Next(1, 4);
-            for (int i = 0; i < wingcount; i++)
-            {
-                wingselect(player);
-            }
-            base.RightClick(player);
+            base.ModifyItemLoot(itemLoot);
+
+            itemLoot.Add(new RepeatRules(1, 3, 1, 1,
+                ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.AngelWings, ItemID.DemonWings, ItemID.FinWings, ItemID.Jetpack, ItemID.BeeWings, ItemID.ButterflyWings, ItemID.FairyWings, ItemID.BatWings, ItemID.HarpyWings, ItemID.BoneWings, ItemID.WillsWings, ItemID.CrownosWings, ItemID.DTownsWings, ItemID.CenxsWings, ItemID.BoneWings, ItemID.BejeweledValkyrieWing, ItemID.Yoraiz0rWings, ItemID.LokisWings, ItemID.JimsWings, ItemID.SkiphsWings, ItemID.RedsWings, ItemID.ArkhalisWings, ItemID.LeinforsWings, ItemID.MothronWings, ItemID.LeafWings, ItemID.FrozenWings, ItemID.FlameWings, ItemID.GhostWings, ItemID.BeetleWings, ItemID.Hoverboard, ItemID.FestiveWings, ItemID.SpookyWings, ItemID.TatteredFairyWings, ItemID.BetsyWings, ItemID.SteampunkWings, ItemID.FishronWings, ItemID.WingsNebula, ItemID.WingsVortex, ItemID.WingsStardust, ItemID.FlyingCarpet, ItemID.WingsSolar)));
         }
-        public void wingselect(Player player)
-        {
-            switch (Main.rand.Next(41))
-            {
-                case 0:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.AngelWings, 1);
-                    break;
-                case 1:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DemonWings, 1);
-                    break;
-                case 2:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FinWings, 1);
-                    break;
-                case 3:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Jetpack, 1);
-                    break;
-                case 4:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BeeWings, 1);
-                    break;
-                case 5:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ButterflyWings, 1);
-                    break;
-                case 6:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FairyWings, 1);
-                    break;
-                case 7:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BatWings, 1);
-                    break;
-                case 8:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.HarpyWings, 1);
-                    break;
-                case 9:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BoneWings, 1);
-                    break;
-                case 10:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.WillsWings, 1);
-                    break;
-                case 11:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CrownosWings, 1);
-                    break;
-                case 12:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.DTownsWings, 1);
-                    break;
-                case 13:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.CenxsWings, 1);
-                    break;
-                case 14:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BoneWings, 1);
-                    break;
-                case 15:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),3228, 1);
-                    break;
-                case 16:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Yoraiz0rWings, 1);
-                    break;
-                case 17:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.LokisWings, 1);
-                    break;
-                case 18:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.JimsWings, 1);
-                    break;
-                case 19:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SkiphsWings, 1);
-                    break;
-                case 20:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.RedsWings, 1);
-                    break;
-                case 21:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.ArkhalisWings, 1);
-                    break;
-                case 22:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.LeinforsWings, 1);
-                    break;
-                case 23:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.MothronWings, 1);
-                    break;
-                case 24:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.LeafWings, 1);
-                    break;
-                case 25:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FrozenWings, 1);
-                    break;
-                case 26:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FlameWings, 1);
-                    break;
-                case 27:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),823, 1);
-                    break;
-                case 28:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BeetleWings, 1);
-                    break;
-                case 29:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.Hoverboard, 1);
-                    break;
-                case 30:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FestiveWings, 1);
-                    break;
-                case 31:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SpookyWings, 1);
-                    break;
-                case 32:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.TatteredFairyWings, 1);
-                    break;
-                case 33:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.BetsyWings, 1);
-                    break;
-                case 34:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.SteampunkWings, 1);
-                    break;
-                case 35:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FishronWings, 1);
-                    break;
-                case 36:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.WingsNebula, 1);
-                    break;
-                case 37:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.WingsVortex, 1);
-                    break;
-                case 38:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.WingsStardust, 1);
-                    break;
-                case 39:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.FlyingCarpet, 1);
-                    break;
-                default:
-                    player.QuickSpawnItem(new EntitySource_ItemOpen(player,Type,"crate"),ItemID.WingsSolar, 1);
-                    break;
-            }
-         }
-      }
-   }
+    }
+}

--- a/NPCs/CrateMimic.cs
+++ b/NPCs/CrateMimic.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.Xna.Framework;
-using System;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.GameContent.Bestiary;
+using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
 using Terraria.ModLoader;
 using UnuBattleRodsR.Items.Crates;
@@ -23,23 +23,21 @@ namespace UnuBattleRodsR.NPCs
 
         public override void SetDefaults()
         {
-         
             base.NPC.width = 24;
             base.NPC.height = 24;
-            
+
             base.NPC.rarity = 2;
             base.NPC.HitSound = SoundID.NPCHit3;
             base.NPC.DeathSound = SoundID.NPCDeath6;
-           
-           
+
             this.Banner = 16;
             this.BannerItem = ItemID.MimicBanner;
             base.NPC.aiStyle = 25;
-          
+
             Main.npcFrameCount[base.NPC.type] = 24;
             this.AnimationType = 85;
 
-            if(Main.rand == null)
+            if (Main.rand == null)
             {
                 Main.rand = new Terraria.Utilities.UnifiedRandom();
             }
@@ -69,14 +67,15 @@ namespace UnuBattleRodsR.NPCs
                 base.NPC.knockBackResist = 0.1f;
             }
         }
+
         public override void SetBestiary(BestiaryDatabase database, BestiaryEntry bestiaryEntry)
         {
-
             bestiaryEntry.Info.AddRange(new List<IBestiaryInfoElement> {
                 new MoonLordPortraitBackgroundProviderBestiaryInfoElement(),
                 new FlavorTextBestiaryInfoElement("The Crate Mimic is a mean crate that attacks anyone that tries to open it.")
             });
         }
+
         public override float SpawnChance(NPCSpawnInfo spawnInfo)
         {
             return 0f;
@@ -104,95 +103,16 @@ namespace UnuBattleRodsR.NPCs
             }
         }
 
-        /*public override void ModifyNPCLoot(NPCLoot npcLoot)
+        public override void ModifyNPCLoot(NPCLoot npcLoot)
         {
-                
-        }*/
+            Crate.AddHealthPotionDrops(npcLoot);
+            Crate.AddBaitDrops(npcLoot);
 
-        public override void OnKill()
-        {
-            int id = 0; int stack = 0;
-
-            Crate.spawnBait(ref id, ref stack);
-            Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, id, stack);
-            Crate.spawnHealthPotion(ref id, ref stack);
-            Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, id, stack);
-
-            if (Main.rand.Next(3) == 0)
-            {
-                switch (Main.rand.Next(5))
-                {
-                    case 0:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.Sextant);
-                        break;
-                    case 1:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.FishermansGuide);
-                        break;
-                    case 2:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.WeatherRadio);
-                        break;
-                    case 3:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.DepthMeter);
-                        break;
-                    default:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.Compass);
-                        break;
-                }
-            }
-            else if(Main.rand.Next(5) == 0)
-            {
-                
-                    switch (Main.rand.Next(6))
-                    {
-                        case 1:
-                            Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.AnglerHat);
-                            break;
-                        case 2:
-                            Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.AnglerPants);
-                            break;
-                        case 3:
-                            Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.HighTestFishingLine);
-                            break;
-                        case 4:
-                            Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.AnglerVest);
-                            break;
-                        case 5:
-                            Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.AnglerEarring);
-                            break;
-                        default:
-                            Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.TackleBox);
-                            break;
-                    }
-                
-
-            }
-            else
-            {
-                switch (Main.rand.Next(6))
-                {
-                    case 1:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.StarCloak);
-                        break;
-                    case 2:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.DualHook);
-                        break;
-                    case 3:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.MagicDagger);
-                        break;
-                    case 4:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.PhilosophersStone);
-                        break;
-                    case 5:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.CrossNecklace);
-                        break;
-                    default:
-                        Item.NewItem(NPC.GetSource_FromThis(), NPC.Center, Vector2.Zero, ItemID.TitanGlove);
-                        break;
-                }
-            }
-            
+            npcLoot.Add(new SequentialRulesNotScalingWithLuckRule(1,
+                ItemDropRule.OneFromOptionsNotScalingWithLuck(3, ItemID.Sextant, ItemID.FishermansGuide, ItemID.WeatherRadio, ItemID.DepthMeter, ItemID.Compass),
+                ItemDropRule.OneFromOptionsNotScalingWithLuck(5, ItemID.AnglerHat, ItemID.AnglerVest, ItemID.AnglerPants, ItemID.HighTestFishingLine, ItemID.AnglerEarring, ItemID.TackleBox),
+                ItemDropRule.OneFromOptionsNotScalingWithLuck(1, ItemID.StarCloak, ItemID.DualHook, ItemID.MagicDagger, ItemID.PhilosophersStone, ItemID.CrossNecklace, ItemID.TitanGlove)
+            ));
         }
     }
 }
-
-


### PR DESCRIPTION
Ports all of the mod's crates and the Mimic Crate NPC to use the item loot database. The Cooler Boss already used it, so no changes there.

Logic changes:
- Some max drop amounts have gone up or down by 1
- The Alien Crate now actually drops the Cosmic Car Key and Anti Gravity Hook.
- The Cobweb Crate no longer drops the Amber Robe twice as much as other armor pieces.
- The Dye Crate's chance to drop a dye is changed, but similar to what it was before.
- The Eclipse Crate now properly drops Broken Hero Fragments (Thorium Mod) instead of trying to drop Broken Hero Bows, Staffs, and Scythes.
- The Lihzahrd Crate now drops Golem loot 10% of the time instead of 0.04% of the time.

Notes:
- The Flower Crate and Fruit Crate did not drop normal crate loot before my changes; I am not sure if this was intentional, but the behavior was kept.